### PR TITLE
feat: Local Development MVP - File-based Registry and SimpleNANDA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,11 @@ dist/
 *.egg-info/
 
 nanda_adapter/core/__pycache__
+
+# Planning and local development documents (NEVER push to origin/upstream)
+CLAUDE.md
+TESTING.md
+*.local.md
+.nanda_registry.json
+logs/
+**/logs_*/

--- a/README_MVP.md
+++ b/README_MVP.md
@@ -1,0 +1,387 @@
+# NANDA Adapter v2.0 - Local Development MVP
+
+**Simple, local-first agent-to-agent communication.**
+
+No external registries. No SSL certificates. No complex setup.
+Just Python, a few lines of code, and you're running multi-agent systems locally.
+
+---
+
+## Quick Start (2 Minutes)
+
+### 1. Install
+
+```bash
+pip install anthropic python-a2a
+```
+
+### 2. Set API Key
+
+```bash
+export ANTHROPIC_API_KEY=sk-your-key-here
+```
+
+### 3. Run Two Agents
+
+**Terminal 1 - Agent A:**
+```bash
+python examples/two_agents_local.py agent_a
+```
+
+**Terminal 2 - Agent B:**
+```bash
+python examples/two_agents_local.py agent_b
+```
+
+**Terminal 3 - Test Communication:**
+```bash
+curl -X POST http://localhost:6000/a2a \
+  -H "Content-Type: application/json" \
+  -d '{
+    "role": "user",
+    "content": {"type": "text", "text": "@agent_b What is 2+2?"},
+    "conversation_id": "test"
+  }'
+```
+
+**Expected Output:**
+```json
+{
+  "role": "agent",
+  "content": {"type": "text", "text": "[agent_a] Message sent to agent_b"},
+  "conversation_id": "test"
+}
+```
+
+Check agent_b's terminal - you'll see Claude's response!
+
+---
+
+## Features
+
+✅ **File-Based Registry** - No MongoDB, no external services
+✅ **HTTP for Local** - No SSL certificates needed
+✅ **Loop Prevention** - Depth tracking prevents infinite loops
+✅ **JSONL Logging** - Easy debugging with standard tools
+✅ **Optional Claude** - Works with or without API key
+✅ **host:port Flexibility** - localhost, remote IPs (192.168.1.100:6002)
+✅ **Modern Python** - Type hints, docstrings, best practices
+✅ **101 Tests** - Comprehensive test coverage
+
+---
+
+## Usage Examples
+
+### Basic Agent (With Claude)
+
+```python
+from nanda_adapter.simple import SimpleNANDA
+
+agent = SimpleNANDA('my_agent', 'localhost:6000')
+agent.start()
+```
+
+### Agent Without Claude (Custom Logic)
+
+```python
+from nanda_adapter.simple import SimpleNANDA
+
+def my_improver(text):
+    return text.upper()
+
+agent = SimpleNANDA(
+    'simple_agent',
+    'localhost:6000',
+    improvement_logic=my_improver,
+    require_anthropic=False  # No API key needed!
+)
+agent.start()
+```
+
+### Remote Host
+
+```python
+# Agent on specific IP address
+agent = SimpleNANDA('agent_c', '192.168.1.100:6004')
+agent.start()
+```
+
+---
+
+## How It Works
+
+### 1. Agent Registration
+
+Agents automatically register in `.nanda_registry.json`:
+
+```json
+{
+  "agent_a": {
+    "agent_url": "http://localhost:6000",
+    "registered_at": "2025-09-29T10:00:00Z",
+    "last_seen": "2025-09-29T10:00:00Z"
+  },
+  "agent_b": {
+    "agent_url": "http://localhost:6002",
+    "registered_at": "2025-09-29T10:01:00Z",
+    "last_seen": "2025-09-29T10:01:00Z"
+  }
+}
+```
+
+### 2. Message Flow
+
+```
+User → Agent A: "@agent_b What is 2+2?"
+        ↓
+Agent A looks up agent_b in registry
+        ↓
+Agent A → Agent B: A2A message (depth=0)
+        ↓
+Agent B → Claude: "What is 2+2?"
+        ↓
+Agent B → Agent A: Response (depth=1)
+        ↓
+Agent A logs response (max depth reached, no loop)
+```
+
+### 3. Loop Prevention
+
+- **depth=0**: Initial request
+- **depth=1**: Response (MAX - stops here)
+- **depth>=1**: Logged but not responded to
+
+This prevents infinite agent-to-agent loops.
+
+---
+
+## Testing with curl
+
+### Send to Another Agent
+
+```bash
+curl -X POST http://localhost:6000/a2a \
+  -H "Content-Type: application/json" \
+  -d '{
+    "role": "user",
+    "content": {"type": "text", "text": "@agent_b Hello!"},
+    "conversation_id": "conv_001"
+  }'
+```
+
+### Query Local Agent Directly
+
+```bash
+curl -X POST http://localhost:6000/a2a \
+  -H "Content-Type: application/json" \
+  -d '{
+    "role": "user",
+    "content": {"type": "text", "text": "/query What is A2A?"},
+    "conversation_id": "conv_002"
+  }'
+```
+
+### Get Help
+
+```bash
+curl -X POST http://localhost:6000/a2a \
+  -H "Content-Type: application/json" \
+  -d '{
+    "role": "user",
+    "content": {"type": "text", "text": "/help"},
+    "conversation_id": "help"
+  }'
+```
+
+---
+
+## Conversation Logs
+
+Logs are automatically saved in JSONL format:
+
+```bash
+# View logs
+cat logs/agent_agent_a/conversation_test.jsonl
+
+# Pretty print with jq
+cat logs/agent_agent_a/conversation_test.jsonl | jq .
+
+# Watch in real-time
+tail -f logs/agent_agent_a/conversation_test.jsonl
+```
+
+**Log Format:**
+```json
+{"timestamp":"2025-09-29T10:05:00Z","agent_id":"agent_a","conversation_id":"test","source":"incoming","message":"@agent_b Hello"}
+{"timestamp":"2025-09-29T10:05:01Z","agent_id":"agent_a","conversation_id":"test","source":"outgoing","message":"[agent_a] Message sent to agent_b"}
+```
+
+---
+
+## Configuration
+
+### Constructor Parameters
+
+```python
+SimpleNANDA(
+    agent_id: str,                    # Required: Unique agent identifier
+    host: str = "localhost:6000",     # hostname:port
+    improvement_logic: Callable = None,  # Optional message transformer
+    anthropic_api_key: str = None,    # Or use ANTHROPIC_API_KEY env var
+    require_anthropic: bool = True,   # Set False for no Claude
+    registry: LocalRegistry = None,   # Custom registry instance
+    log_dir: str = "./logs"          # Base log directory
+)
+```
+
+### Environment Variables
+
+Only **one** required (if using Claude):
+
+```bash
+ANTHROPIC_API_KEY=sk-your-key-here
+```
+
+That's it! Everything else has sensible defaults.
+
+---
+
+## Commands
+
+Agents support these commands:
+
+- **`@agent_id message`** - Send to another agent
+- **`/query question`** - Query Claude directly (no routing)
+- **`/help`** - Show available commands
+
+---
+
+## Architecture
+
+### Core Modules (~650 LOC)
+
+```
+nanda_adapter/
+├── core/
+│   ├── registry.py      # File-based JSON registry
+│   ├── protocol.py      # A2A message format + depth
+│   ├── router.py        # Message routing + loops
+│   └── logger.py        # JSONL conversation logs
+└── simple.py            # SimpleNANDA entry point
+```
+
+### Tests (101 tests, all passing)
+
+```
+tests/unit/
+├── test_registry.py     # 16 tests
+├── test_protocol.py     # 30 tests
+├── test_router.py       # 32 tests
+└── test_logger.py       # 23 tests
+```
+
+---
+
+## Troubleshooting
+
+### "Agent not found in registry"
+
+```bash
+# Clear registry and restart agents
+rm .nanda_registry.json
+python examples/two_agents_local.py agent_a  # In terminal 1
+python examples/two_agents_local.py agent_b  # In terminal 2
+```
+
+### "Connection refused"
+
+```bash
+# Check agent is running
+lsof -i :6000
+
+# Verify correct port
+curl http://localhost:6000/a2a -v
+```
+
+### "ANTHROPIC_API_KEY not set"
+
+```bash
+# Set environment variable
+export ANTHROPIC_API_KEY=sk-your-key-here
+
+# Or run without Claude
+python examples/simple_agent_no_claude.py
+```
+
+---
+
+## What's Different from v1.x?
+
+| Feature | v1.x | v2.0 MVP |
+|---------|------|----------|
+| **Registry** | External HTTPS | File-based JSON |
+| **SSL** | Required | Not needed (HTTP) |
+| **Setup Time** | ~15 min | < 2 min |
+| **Dependencies** | 4+ (registry, certs) | 2 (Python libs) |
+| **Env Vars** | 16 | 1 (API key) |
+| **Offline** | ❌ No | ✅ Yes |
+| **Tests** | 0 | 101 |
+| **LOC** | ~2,400 | ~650 core |
+
+---
+
+## Next Steps
+
+### Run the Examples
+
+```bash
+# With Claude
+python examples/two_agents_local.py agent_a
+
+# Without Claude
+python examples/simple_agent_no_claude.py
+```
+
+### Read the Docs
+
+- [Git Workflow](docs/GIT_WORKFLOW.md) - Branch naming, commit conventions
+- [Testing Guide](docs/TESTING_GUIDE.md) - curl examples, debugging
+- [Registry Spec](docs/REGISTRY_SPECIFICATION.md) - Local vs external
+- [Bugs Fixed](docs/BUGS_AND_ISSUES.md) - API key lazy loading
+
+### Build Your Own
+
+```python
+from nanda_adapter.simple import SimpleNANDA
+
+# Your custom improvement logic
+def my_logic(text):
+    # Transform messages however you want
+    return f"Enhanced: {text}"
+
+agent = SimpleNANDA(
+    'my_agent',
+    'localhost:6000',
+    improvement_logic=my_logic
+)
+agent.start()
+```
+
+---
+
+## License
+
+[Your License Here]
+
+## Contributing
+
+See [docs/GIT_WORKFLOW.md](docs/GIT_WORKFLOW.md) for branch naming and commit conventions.
+
+**Important**: Never include AI tool branding in commits.
+
+---
+
+**Version**: 2.0.0-dev
+**Branch**: feature/local-development-mvp
+**Tests**: 101 passing
+**Status**: Ready for PR

--- a/README_MVP.md
+++ b/README_MVP.md
@@ -376,5 +376,3 @@ agent.start()
 ## Contributing
 
 See [docs/GIT_WORKFLOW.md](docs/GIT_WORKFLOW.md) for branch naming and commit conventions.
-
-**Important**: Never include AI tool branding in commits.

--- a/README_MVP.md
+++ b/README_MVP.md
@@ -378,10 +378,3 @@ agent.start()
 See [docs/GIT_WORKFLOW.md](docs/GIT_WORKFLOW.md) for branch naming and commit conventions.
 
 **Important**: Never include AI tool branding in commits.
-
----
-
-**Version**: 2.0.0-dev
-**Branch**: feature/local-development-mvp
-**Tests**: 101 passing
-**Status**: Ready for PR

--- a/docs/GIT_WORKFLOW.md
+++ b/docs/GIT_WORKFLOW.md
@@ -1,0 +1,435 @@
+# Git Workflow and Commit Conventions
+
+**Version**: 1.0
+**Date**: 2025-09-29
+**Project**: NANDA Adapter v2.0 Refactoring
+
+---
+
+## Branching Strategy
+
+### Main Branch
+
+- `main` - Production-ready code, current v1.x
+- Protected: No direct commits
+- All changes via Pull Requests
+
+### Feature Branches
+
+**Naming Convention**: `feature/<scope>-<brief-description>`
+
+**Examples**:
+```bash
+feature/local-registry           # Day 1: File-based registry
+feature/protocol-loop-prevention # Day 2: Protocol module
+feature/router-depth-tracking    # Day 3: Router module
+feature/simple-nanda-entry       # Day 4-5: SimpleNANDA class
+feature/testing-integration      # Integration tests
+feature/docs-readme-rewrite      # Documentation updates
+```
+
+### Creating Feature Branches
+
+```bash
+# Start from main
+git checkout main
+git pull origin main
+
+# Create feature branch
+git checkout -b feature/local-registry
+
+# Work on feature...
+# Commit regularly (see commit guidelines below)
+
+# Push to remote
+git push -u origin feature/local-registry
+```
+
+---
+
+## Commit Guidelines
+
+### Frequency
+
+**Commit when**:
+- ✅ Completing a logical unit of work (function, class, test suite)
+- ✅ Finishing a file or module
+- ✅ Before switching to a different task
+- ✅ Code is in working state (tests pass)
+- ✅ End of work session
+
+**Don't commit**:
+- ❌ After every line change (too granular)
+- ❌ With failing tests (unless explicitly WIP)
+- ❌ Mixed concerns in single commit
+
+**Rule of thumb**: Commit every 30-60 minutes of focused work, or when completing a feature component.
+
+### Commit Message Format
+
+**Structure**:
+```
+<type>: <subject>
+
+<body (optional)>
+```
+
+**Types**:
+- `feat`: New feature
+- `fix`: Bug fix
+- `refactor`: Code restructuring (no behavior change)
+- `test`: Adding or updating tests
+- `docs`: Documentation changes
+- `chore`: Build, dependencies, tooling
+
+**Subject Line**:
+- ✅ Imperative mood ("Add registry", not "Added registry")
+- ✅ Lowercase start
+- ✅ No period at end
+- ✅ Max 72 characters
+- ✅ Describe WHAT, not HOW
+
+**Body (optional)**:
+- Why the change was made
+- What problem it solves
+- Any important context
+- Breaking changes
+
+---
+
+## Commit Examples
+
+### Good Commits
+
+```bash
+# Simple, clear
+git commit -m "feat: add file-based local registry"
+
+# With context
+git commit -m "feat: add LocalRegistry class
+
+Implements file-based registry using JSON for local development.
+Supports register, lookup, list, and unregister operations.
+Data persists to .nanda_registry.json file."
+
+# Bug fix
+git commit -m "fix: validate API key before creating Anthropic client
+
+Previously, client was created at module import time even if not needed.
+Now uses lazy initialization to only create when required."
+
+# Test addition
+git commit -m "test: add unit tests for LocalRegistry
+
+Covers all CRUD operations plus file persistence."
+
+# Refactoring
+git commit -m "refactor: extract protocol parsing to separate module
+
+Moves format_a2a_message and parse_a2a_message from agent_bridge
+to new protocol.py module. No behavior changes."
+
+# Documentation
+git commit -m "docs: update README with curl testing examples"
+```
+
+### Bad Commits (Avoid)
+
+```bash
+# Too vague
+git commit -m "update code"
+git commit -m "fixes"
+git commit -m "changes"
+
+# Past tense
+git commit -m "Added registry"  # Use "add" not "added"
+
+# Too granular
+git commit -m "add comma"
+git commit -m "fix typo"
+
+# Mixed concerns
+git commit -m "add registry, fix bug, update docs"  # Should be 3 commits
+```
+
+---
+
+## Workflow Example: Day 1 (Local Registry)
+
+```bash
+# Start feature
+git checkout -b feature/local-registry
+
+# Create registry interface
+# ... write code ...
+git add nanda_adapter/core/registry_interface.py
+git commit -m "feat: add RegistryInterface abstract base class"
+
+# Implement LocalRegistry
+# ... write code ...
+git add nanda_adapter/core/local_registry.py
+git commit -m "feat: implement LocalRegistry with file persistence
+
+Uses JSON file (.nanda_registry.json) to store agent registrations.
+Supports register, lookup, list, unregister, and clear operations."
+
+# Add tests
+# ... write tests ...
+git add tests/unit/test_local_registry.py
+git commit -m "test: add unit tests for LocalRegistry
+
+Covers all CRUD operations, file persistence, and error cases."
+
+# Run tests, fix issues
+# ... fix bugs ...
+git add nanda_adapter/core/local_registry.py
+git commit -m "fix: handle missing registry file on first load"
+
+# Day complete, push
+git push -u origin feature/local-registry
+```
+
+**Result**: 4 clean, focused commits
+
+---
+
+## Workflow Example: Day 3 (Router Module)
+
+```bash
+git checkout -b feature/router-depth-tracking
+
+# Implement router class
+git add nanda_adapter/core/router.py
+git commit -m "feat: add MessageRouter with depth tracking
+
+Routes @agent_id, /query, and /help commands.
+Includes depth parameter to prevent message loops."
+
+# Add loop prevention logic
+git add nanda_adapter/core/router.py
+git commit -m "feat: implement depth limit check in router
+
+Prevents infinite loops by enforcing max_depth=1 (request-response only)."
+
+# Add tests
+git add tests/unit/test_router.py
+git commit -m "test: add unit tests for MessageRouter
+
+Tests routing logic, depth limits, and error handling."
+
+# Integration with protocol
+git add nanda_adapter/core/router.py
+git commit -m "refactor: integrate protocol module with router
+
+Router now uses format_a2a_message and parse_a2a_message from protocol module."
+
+git push -u origin feature/router-depth-tracking
+```
+
+---
+
+## Pull Request Process
+
+### 1. Before Creating PR
+
+```bash
+# Ensure all commits are clean
+git log --oneline
+
+# Rebase on main (if needed)
+git fetch origin main
+git rebase origin/main
+
+# Run all tests
+pytest
+
+# Push final changes
+git push origin feature/local-registry
+```
+
+### 2. Create PR
+
+**Title**: Same as feature scope
+- `feat: local registry implementation`
+- `refactor: extract protocol module`
+
+**Description Template**:
+```markdown
+## Summary
+Brief description of what this PR does.
+
+## Changes
+- List of key changes
+- Organized by file/module
+
+## Testing
+- How to test the changes
+- What tests were added
+
+## Related
+- Closes #<issue-number> (if applicable)
+- Part of: MVP Implementation Plan Day X
+```
+
+### 3. PR Review Checklist
+
+- [ ] All tests pass
+- [ ] No merge conflicts
+- [ ] Commit messages follow conventions
+- [ ] No advertising/branding in commits
+- [ ] Code follows project style
+- [ ] Documentation updated (if needed)
+
+### 4. Merge
+
+**Method**: Squash and merge (preferred for MVP)
+- Combines all commits into single commit on main
+- Keeps main history clean
+
+**Alternative**: Merge commit (if commits are well-organized)
+
+---
+
+## Commit Amending (Use Sparingly)
+
+**When to amend**:
+- Fix typo in last commit
+- Add forgotten file to last commit
+- **Before pushing** (local only)
+
+```bash
+# Fix typo, add to last commit
+git add file.py
+git commit --amend --no-edit
+
+# Change last commit message
+git commit --amend -m "feat: corrected commit message"
+```
+
+**NEVER amend**:
+- After pushing (breaks history for others)
+- Commits that others have based work on
+
+---
+
+## Stashing Changes
+
+**Use case**: Need to switch branches mid-work
+
+```bash
+# Save work in progress
+git stash push -m "WIP: router depth tracking"
+
+# Switch branches
+git checkout main
+
+# Return and restore
+git checkout feature/router-depth-tracking
+git stash pop
+```
+
+---
+
+## Checking Commit History
+
+```bash
+# View recent commits
+git log --oneline -10
+
+# View commits with diffs
+git log -p -2
+
+# View commits by author
+git log --author="Your Name"
+
+# Search commit messages
+git log --grep="registry"
+
+# View file history
+git log --follow -- nanda_adapter/core/registry.py
+```
+
+---
+
+## Example: Full Day Workflow
+
+```bash
+# Morning: Start fresh
+git checkout main
+git pull origin main
+git checkout -b feature/protocol-loop-prevention
+
+# Work session 1 (9am - 10:30am)
+# Implement protocol.py
+git add nanda_adapter/core/protocol.py
+git commit -m "feat: add A2AMessage dataclass with depth fields"
+
+# Work session 2 (10:30am - 12pm)
+# Add format/parse functions
+git add nanda_adapter/core/protocol.py
+git commit -m "feat: implement format_a2a_message and parse_a2a_message
+
+Handles depth, max_depth, and message_type fields for loop prevention."
+
+# Lunch break
+
+# Work session 3 (1pm - 3pm)
+# Write tests
+git add tests/unit/test_protocol.py
+git commit -m "test: add comprehensive protocol tests
+
+Tests formatting, parsing, round-trip, and depth field handling."
+
+# Work session 4 (3pm - 5pm)
+# Fix bugs found in testing
+git add nanda_adapter/core/protocol.py
+git commit -m "fix: handle missing depth fields in legacy messages
+
+Defaults to depth=0, max_depth=1 for backward compatibility."
+
+# End of day
+git push -u origin feature/protocol-loop-prevention
+```
+
+**Result**: 4 commits, clean history, logical progression
+
+---
+
+## Emergency: Undo Last Commit
+
+```bash
+# Keep changes, undo commit
+git reset --soft HEAD~1
+
+# Discard changes, undo commit (DANGEROUS)
+git reset --hard HEAD~1
+
+# Already pushed? Create revert commit
+git revert HEAD
+git push origin feature/branch-name
+```
+
+---
+
+## Summary
+
+### Branching
+- ✅ One feature branch per MVP day or logical feature
+- ✅ Name: `feature/<scope>-<description>`
+- ✅ Start from `main`, merge back via PR
+
+### Commits
+- ✅ Commit every 30-60 minutes or logical completion
+- ✅ Format: `<type>: <subject>`
+- ✅ Clear, factual, no advertising
+- ✅ Imperative mood, lowercase, no period
+
+### Pull Requests
+- ✅ Create when feature complete
+- ✅ Descriptive title and description
+- ✅ All tests pass
+- ✅ Squash and merge to keep main clean
+
+---
+
+**Next**: See [MVP_IMPLEMENTATION_PLAN.md](./MVP_IMPLEMENTATION_PLAN.md) for feature branch breakdown by day.

--- a/examples/simple_agent_no_claude.py
+++ b/examples/simple_agent_no_claude.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Simple Agent Without Claude.
+
+Demonstrates SimpleNANDA with custom improvement logic,
+no Claude API key required.
+
+This example shows how to create agents that work completely
+offline with custom message processing logic.
+
+Usage:
+    python examples/simple_agent_no_claude.py
+"""
+
+import sys
+from pathlib import Path
+
+# Ensure local nanda_adapter is used
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from nanda_adapter.simple import SimpleNANDA
+
+
+def uppercase_improver(text: str) -> str:
+    """Simple message transformer - converts to uppercase."""
+    return text.upper()
+
+
+def pirate_improver(text: str) -> str:
+    """Transform messages to pirate speak."""
+    replacements = {
+        "hello": "ahoy",
+        "hi": "ahoy",
+        "yes": "aye",
+        "no": "nay",
+        "you": "ye",
+        "your": "yer",
+        "my": "me",
+        "friend": "matey",
+        "is": "be",
+        "are": "be",
+    }
+
+    result = text
+    for old, new in replacements.items():
+        # Case insensitive replacement
+        import re
+        result = re.sub(re.escape(old), new, result, flags=re.IGNORECASE)
+
+    return result + ", arrr!"
+
+
+def main():
+    print("=" * 60)
+    print("Simple Agent - No Claude Required")
+    print("=" * 60)
+    print("\nThis agent uses custom improvement logic (pirate speak)")
+    print("No ANTHROPIC_API_KEY needed!\n")
+
+    # Create agent with custom logic, no Claude
+    agent = SimpleNANDA(
+        agent_id="simple_agent",
+        host="localhost:6000",
+        improvement_logic=pirate_improver,
+        require_anthropic=False  # No Claude needed!
+    )
+
+    print("\nTry sending:")
+    print("  curl -X POST http://localhost:6000/a2a \\")
+    print("    -H 'Content-Type: application/json' \\")
+    print("    -d '{\"role\":\"user\",\"content\":{\"type\":\"text\",\"text\":\"Hello friend!\"},\"conversation_id\":\"test\"}'")
+    print()
+
+    agent.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/two_agents_local.py
+++ b/examples/two_agents_local.py
@@ -22,6 +22,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from nanda_adapter.simple import SimpleNANDA
+from nanda_adapter.core.registry import LocalRegistry
 
 
 def main():
@@ -52,12 +53,17 @@ def main():
         print("=" * 60)
         sys.exit(1)
 
+    # Create shared registry in project root (not examples dir)
+    registry_path = PROJECT_ROOT / ".nanda_registry.json"
+    registry = LocalRegistry(str(registry_path))
+
     # Create and start agent
     print("=" * 60)
     print(f"Starting {agent_id} with Claude integration")
     print("=" * 60)
+    print(f"Shared registry: {registry_path}")
 
-    agent = SimpleNANDA(agent_id, host)
+    agent = SimpleNANDA(agent_id, host, registry=registry)
     agent.start()
 
 

--- a/examples/two_agents_local.py
+++ b/examples/two_agents_local.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""
+Two-Agent Local Communication Example.
+
+Demonstrates SimpleNANDA with two agents communicating locally
+without external registries, SSL, or complex setup.
+
+Usage:
+    Terminal 1: python examples/two_agents_local.py agent_a
+    Terminal 2: python examples/two_agents_local.py agent_b
+    Terminal 3: curl -X POST http://localhost:6000/a2a -H "Content-Type: application/json" \\
+                -d '{"role":"user","content":{"type":"text","text":"@agent_b What is 2+2?"},"conversation_id":"test"}'
+"""
+
+import sys
+import os
+from pathlib import Path
+
+# Ensure local nanda_adapter is used
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from nanda_adapter.simple import SimpleNANDA
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python two_agents_local.py <agent_id>")
+        print("Example: python two_agents_local.py agent_a")
+        sys.exit(1)
+
+    agent_id = sys.argv[1]
+
+    # Determine port based on agent ID
+    if agent_id == "agent_a":
+        host = "localhost:6000"
+    elif agent_id == "agent_b":
+        host = "localhost:6002"
+    else:
+        host = f"localhost:{6000 + hash(agent_id) % 1000}"
+
+    # Check for API key
+    if not os.getenv("ANTHROPIC_API_KEY"):
+        print("=" * 60)
+        print("ERROR: ANTHROPIC_API_KEY not set")
+        print("=" * 60)
+        print("\nPlease set your API key:")
+        print("  export ANTHROPIC_API_KEY=sk-your-key-here")
+        print("\nOr run without Claude:")
+        print("  python examples/simple_agent_no_claude.py")
+        print("=" * 60)
+        sys.exit(1)
+
+    # Create and start agent
+    print("=" * 60)
+    print(f"Starting {agent_id} with Claude integration")
+    print("=" * 60)
+
+    agent = SimpleNANDA(agent_id, host)
+    agent.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/nanda_adapter/__init__.py
+++ b/nanda_adapter/__init__.py
@@ -4,27 +4,36 @@ NANDA Agent Framework - Customizable AI Agent Communication System
 
 This package provides a framework for creating customizable AI agents with pluggable
 message improvement logic, built on top of the python_a2a communication framework.
+
+Note: v2.0 refactor in progress. Old v1.x imports preserved for backward compatibility.
 """
 
-from .core.nanda import NANDA
-from .core.agent_bridge import (
-    AgentBridge, 
-    message_improver, 
-    register_message_improver, 
-    get_message_improver, 
-    list_message_improvers
-)
-
-__version__ = "1.0.0"
+__version__ = "2.0.0-dev"
 __author__ = "NANDA Team"
 __email__ = "support@nanda.ai"
 
-# Export main classes and functions
-__all__ = [
-    "NANDA",
-    "AgentBridge",
-    "message_improver",
-    "register_message_improver", 
-    "get_message_improver",
-    "list_message_improvers"
-]
+# v1.x backward compatibility imports (only if dependencies available)
+try:
+    from .core.nanda import NANDA
+    from .core.agent_bridge import (
+        AgentBridge,
+        message_improver,
+        register_message_improver,
+        get_message_improver,
+        list_message_improvers
+    )
+
+    __all__ = [
+        "NANDA",
+        "AgentBridge",
+        "message_improver",
+        "register_message_improver",
+        "get_message_improver",
+        "list_message_improvers"
+    ]
+except ImportError:
+    # During v2.0 refactor, old modules may have missing dependencies
+    # New v2.0 code should import directly:
+    #   from nanda_adapter.core.registry import LocalRegistry
+    #   from nanda_adapter.simple import SimpleNANDA  (when available)
+    __all__ = []

--- a/nanda_adapter/core/__init__.py
+++ b/nanda_adapter/core/__init__.py
@@ -3,22 +3,31 @@
 NANDA Agent Framework - Core Components
 
 This module contains the core components of the NANDA agent framework.
+
+Note: v2.0 refactor in progress. Old v1.x imports preserved for backward compatibility.
+New modules (registry.py, protocol.py, router.py) are standalone and don't need imports here.
 """
 
-from .nanda import NANDA
-from .agent_bridge import (
-    AgentBridge, 
-    message_improver, 
-    register_message_improver, 
-    get_message_improver, 
-    list_message_improvers
-)
+# v1.x backward compatibility imports (only if modules exist)
+try:
+    from .nanda import NANDA
+    from .agent_bridge import (
+        AgentBridge,
+        message_improver,
+        register_message_improver,
+        get_message_improver,
+        list_message_improvers
+    )
 
-__all__ = [
-    "NANDA",
-    "AgentBridge",
-    "message_improver",
-    "register_message_improver", 
-    "get_message_improver",
-    "list_message_improvers"
-]
+    __all__ = [
+        "NANDA",
+        "AgentBridge",
+        "message_improver",
+        "register_message_improver",
+        "get_message_improver",
+        "list_message_improvers"
+    ]
+except ImportError:
+    # During v2.0 refactor, old modules may have missing dependencies
+    # New code should import directly: from nanda_adapter.core.registry import LocalRegistry
+    __all__ = []

--- a/nanda_adapter/core/logger.py
+++ b/nanda_adapter/core/logger.py
@@ -1,0 +1,220 @@
+"""
+Conversation logging for NANDA agents.
+
+This module provides simple JSONL (JSON Lines) logging for agent conversations,
+allowing easy debugging and analysis of agent interactions.
+
+Each log entry is a single JSON object on its own line, making it easy to
+process with standard Unix tools (grep, jq, etc.) or load into analytics tools.
+
+Example:
+    >>> from nanda_adapter.core.logger import ConversationLogger
+    >>> logger = ConversationLogger("agent_a")
+    >>> logger.log("conv_001", "incoming", "Hello from agent_b")
+    >>> logger.log("conv_001", "outgoing", "Hello back!")
+
+    # Logs are written to: ./logs/agent_a/conversation_conv_001.jsonl
+"""
+
+import os
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+class ConversationLogger:
+    """
+    Simple JSONL conversation logger for agents.
+
+    Logs are organized by agent and conversation ID, with one JSON object
+    per line. This format is ideal for streaming, debugging, and analysis.
+
+    Attributes:
+        agent_id: Unique identifier for the agent
+        log_dir: Base directory for all logs (default: ./logs)
+        agent_log_dir: Specific directory for this agent's logs
+
+    Directory structure:
+        ./logs/
+        └── agent_{agent_id}/
+            ├── conversation_{conv_id_1}.jsonl
+            ├── conversation_{conv_id_2}.jsonl
+            └── ...
+    """
+
+    def __init__(self, agent_id: str, log_dir: str = "./logs") -> None:
+        """
+        Initialize conversation logger.
+
+        Args:
+            agent_id: Unique identifier for the agent
+            log_dir: Base directory for logs (default: ./logs)
+
+        Raises:
+            ValueError: If agent_id is empty
+        """
+        if not agent_id:
+            raise ValueError("agent_id cannot be empty")
+
+        self.agent_id = agent_id
+        self.log_dir = Path(log_dir)
+        self.agent_log_dir = self.log_dir / f"agent_{agent_id}"
+
+        # Create agent log directory if it doesn't exist
+        self.agent_log_dir.mkdir(parents=True, exist_ok=True)
+
+    def log(
+        self,
+        conversation_id: str,
+        source: str,
+        message: str,
+        metadata: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """
+        Log a message for a conversation.
+
+        Appends a JSON object (one per line) to the conversation's JSONL file.
+        Each entry includes timestamp, agent ID, conversation ID, source,
+        message content, and optional metadata.
+
+        Args:
+            conversation_id: Unique identifier for the conversation
+            source: Origin of the message (e.g., "incoming", "outgoing", "claude")
+            message: The message content to log
+            metadata: Optional additional data to include in log entry
+
+        Example:
+            >>> logger = ConversationLogger("agent_a")
+            >>> logger.log("conv_001", "incoming", "Hello", {"depth": 0})
+            >>> logger.log("conv_001", "outgoing", "Hi there!", {"depth": 1})
+        """
+        log_file = self.agent_log_dir / f"conversation_{conversation_id}.jsonl"
+
+        entry: Dict[str, Any] = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "agent_id": self.agent_id,
+            "conversation_id": conversation_id,
+            "source": source,
+            "message": message
+        }
+
+        # Include optional metadata
+        if metadata:
+            entry["metadata"] = metadata
+
+        # Append to JSONL file (one JSON object per line)
+        with open(log_file, 'a', encoding='utf-8') as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + '\n')
+
+    def get_conversation_log_path(self, conversation_id: str) -> Path:
+        """
+        Get the file path for a conversation's log.
+
+        Args:
+            conversation_id: Unique identifier for the conversation
+
+        Returns:
+            Path to the conversation's JSONL log file
+
+        Example:
+            >>> logger = ConversationLogger("agent_a")
+            >>> path = logger.get_conversation_log_path("conv_001")
+            >>> print(path)
+            logs/agent_a/conversation_conv_001.jsonl
+        """
+        return self.agent_log_dir / f"conversation_{conversation_id}.jsonl"
+
+    def read_conversation(self, conversation_id: str) -> list[Dict[str, Any]]:
+        """
+        Read all log entries for a conversation.
+
+        Parses the JSONL file and returns a list of log entry dictionaries.
+        Returns empty list if log file doesn't exist.
+
+        Args:
+            conversation_id: Unique identifier for the conversation
+
+        Returns:
+            List of log entry dictionaries, in chronological order
+
+        Example:
+            >>> logger = ConversationLogger("agent_a")
+            >>> logger.log("conv_001", "incoming", "Hello")
+            >>> entries = logger.read_conversation("conv_001")
+            >>> len(entries)
+            1
+            >>> entries[0]["message"]
+            'Hello'
+        """
+        log_file = self.get_conversation_log_path(conversation_id)
+
+        if not log_file.exists():
+            return []
+
+        entries = []
+        with open(log_file, 'r', encoding='utf-8') as f:
+            for line in f:
+                line = line.strip()
+                if line:  # Skip empty lines
+                    try:
+                        entries.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        # Skip malformed lines (shouldn't happen, but be defensive)
+                        continue
+
+        return entries
+
+    def list_conversations(self) -> list[str]:
+        """
+        List all conversation IDs that have been logged.
+
+        Returns:
+            List of conversation IDs (without file extensions)
+
+        Example:
+            >>> logger = ConversationLogger("agent_a")
+            >>> logger.log("conv_001", "incoming", "Hello")
+            >>> logger.log("conv_002", "incoming", "Hi")
+            >>> conversations = logger.list_conversations()
+            >>> "conv_001" in conversations
+            True
+            >>> "conv_002" in conversations
+            True
+        """
+        if not self.agent_log_dir.exists():
+            return []
+
+        conversations = []
+        for log_file in self.agent_log_dir.glob("conversation_*.jsonl"):
+            # Extract conversation ID from filename
+            # Format: conversation_{conv_id}.jsonl
+            conv_id = log_file.stem.replace("conversation_", "")
+            conversations.append(conv_id)
+
+        return sorted(conversations)
+
+    def clear_conversation(self, conversation_id: str) -> bool:
+        """
+        Delete all log entries for a conversation.
+
+        Args:
+            conversation_id: Unique identifier for the conversation
+
+        Returns:
+            True if log file was deleted, False if it didn't exist
+
+        Example:
+            >>> logger = ConversationLogger("agent_a")
+            >>> logger.log("conv_001", "incoming", "Hello")
+            >>> logger.clear_conversation("conv_001")
+            True
+            >>> logger.read_conversation("conv_001")
+            []
+        """
+        log_file = self.get_conversation_log_path(conversation_id)
+
+        if log_file.exists():
+            log_file.unlink()
+            return True
+        return False

--- a/nanda_adapter/core/protocol.py
+++ b/nanda_adapter/core/protocol.py
@@ -1,0 +1,221 @@
+"""
+A2A Protocol Message Format with Loop Prevention.
+
+This module implements the Agent-to-Agent (A2A) message protocol format
+used for communication between NANDA agents. It includes depth tracking
+to prevent infinite message loops.
+
+The protocol uses a structured text format with marker tokens to encode
+message metadata (sender, receiver, depth, etc.) alongside the message content.
+
+Example:
+    >>> from nanda_adapter.core.protocol import A2AMessage, format_a2a_message
+    >>> msg = A2AMessage(
+    ...     from_agent="agent_a",
+    ...     to_agent="agent_b",
+    ...     message="Hello!",
+    ...     conversation_id="conv_001"
+    ... )
+    >>> formatted = format_a2a_message(msg)
+    >>> print(formatted)
+    __EXTERNAL_MESSAGE__
+    __FROM_AGENT__agent_a
+    __TO_AGENT__agent_b
+    ...
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class A2AMessage:
+    """
+    Agent-to-Agent message structure.
+
+    Attributes:
+        from_agent: ID of the sending agent
+        to_agent: ID of the receiving agent
+        message: The actual message content
+        conversation_id: Unique identifier for the conversation thread
+        depth: Current message depth (0 = initial request, 1 = response, etc.)
+        max_depth: Maximum allowed depth to prevent infinite loops
+        message_type: Type of message - "query" (request) or "response" (reply)
+
+    The depth tracking mechanism prevents infinite loops:
+        - Initial messages have depth=0
+        - Responses increment depth by 1
+        - When depth >= max_depth, no further responses are sent
+        - Default max_depth=1 allows only request-response pattern
+    """
+
+    from_agent: str
+    to_agent: str
+    message: str
+    conversation_id: str
+    depth: int = 0
+    max_depth: int = 1
+    message_type: str = "query"  # "query" or "response"
+
+    def __post_init__(self) -> None:
+        """Validate message fields after initialization."""
+        if not self.from_agent:
+            raise ValueError("from_agent cannot be empty")
+        if not self.to_agent:
+            raise ValueError("to_agent cannot be empty")
+        if not self.message:
+            raise ValueError("message cannot be empty")
+        # Note: conversation_id can be empty during parsing (set by caller later)
+        if self.depth < 0:
+            raise ValueError(f"depth must be non-negative, got {self.depth}")
+        if self.max_depth < 0:
+            raise ValueError(f"max_depth must be non-negative, got {self.max_depth}")
+        if self.message_type not in ("query", "response"):
+            raise ValueError(f"message_type must be 'query' or 'response', got {self.message_type}")
+
+
+def format_a2a_message(msg: A2AMessage) -> str:
+    """
+    Format an A2A message for transmission.
+
+    Converts an A2AMessage object into the structured text format used
+    for agent-to-agent communication. The format uses marker tokens to
+    delimit metadata fields.
+
+    Args:
+        msg: The A2AMessage object to format
+
+    Returns:
+        Formatted string representation of the message
+
+    Example:
+        >>> msg = A2AMessage(
+        ...     from_agent="agent_a",
+        ...     to_agent="agent_b",
+        ...     message="What is 2+2?",
+        ...     conversation_id="math_001"
+        ... )
+        >>> formatted = format_a2a_message(msg)
+        >>> "__EXTERNAL_MESSAGE__" in formatted
+        True
+    """
+    return f"""__EXTERNAL_MESSAGE__
+__FROM_AGENT__{msg.from_agent}
+__TO_AGENT__{msg.to_agent}
+__MESSAGE_TYPE__{msg.message_type}
+__DEPTH__{msg.depth}
+__MAX_DEPTH__{msg.max_depth}
+__MESSAGE_START__
+{msg.message}
+__MESSAGE_END__"""
+
+
+def parse_a2a_message(raw: str) -> Optional[A2AMessage]:
+    """
+    Parse a raw A2A message string.
+
+    Extracts message metadata and content from the structured text format.
+    Returns None if the message is not in valid A2A format.
+
+    Args:
+        raw: Raw message string to parse
+
+    Returns:
+        A2AMessage object if valid, None otherwise
+
+    Example:
+        >>> formatted = format_a2a_message(A2AMessage(
+        ...     from_agent="agent_a",
+        ...     to_agent="agent_b",
+        ...     message="Hello",
+        ...     conversation_id="conv_001"
+        ... ))
+        >>> parsed = parse_a2a_message(formatted)
+        >>> parsed.from_agent
+        'agent_a'
+        >>> parsed.message
+        'Hello'
+
+    Note:
+        This function is tolerant of missing optional fields and will use
+        sensible defaults (depth=0, max_depth=1, message_type="query").
+    """
+    if not raw or not raw.strip().startswith("__EXTERNAL_MESSAGE__"):
+        return None
+
+    lines = raw.split('\n')
+    from_agent = None
+    to_agent = None
+    message_type = "query"  # Default
+    depth = 0  # Default
+    max_depth = 1  # Default
+    message_lines = []
+    in_message = False
+
+    for line in lines[1:]:  # Skip first line (__EXTERNAL_MESSAGE__)
+        if line.startswith("__FROM_AGENT__"):
+            from_agent = line[len("__FROM_AGENT__"):]
+        elif line.startswith("__TO_AGENT__"):
+            to_agent = line[len("__TO_AGENT__"):]
+        elif line.startswith("__MESSAGE_TYPE__"):
+            message_type = line[len("__MESSAGE_TYPE__"):]
+        elif line.startswith("__DEPTH__"):
+            try:
+                depth = int(line[len("__DEPTH__"):])
+            except ValueError:
+                depth = 0  # Fallback to default
+        elif line.startswith("__MAX_DEPTH__"):
+            try:
+                max_depth = int(line[len("__MAX_DEPTH__"):])
+            except ValueError:
+                max_depth = 1  # Fallback to default
+        elif line == "__MESSAGE_START__":
+            in_message = True
+        elif line == "__MESSAGE_END__":
+            break
+        elif in_message:
+            message_lines.append(line)
+
+    # Validate required fields
+    if not from_agent or not to_agent:
+        return None
+
+    message_content = '\n'.join(message_lines)
+    if not message_content:
+        return None
+
+    try:
+        return A2AMessage(
+            from_agent=from_agent,
+            to_agent=to_agent,
+            message=message_content,
+            conversation_id="",  # Will be set by caller from context
+            depth=depth,
+            max_depth=max_depth,
+            message_type=message_type
+        )
+    except ValueError:
+        # Invalid field values, return None
+        return None
+
+
+def is_a2a_message(raw: str) -> bool:
+    """
+    Check if a string is in A2A message format.
+
+    This is a lightweight check that only looks for the opening marker.
+    Use parse_a2a_message() for full validation and parsing.
+
+    Args:
+        raw: String to check
+
+    Returns:
+        True if string starts with A2A message marker, False otherwise
+
+    Example:
+        >>> is_a2a_message("__EXTERNAL_MESSAGE__\\n...")
+        True
+        >>> is_a2a_message("Hello world")
+        False
+    """
+    return bool(raw and raw.strip().startswith("__EXTERNAL_MESSAGE__"))

--- a/nanda_adapter/core/registry.py
+++ b/nanda_adapter/core/registry.py
@@ -1,0 +1,119 @@
+"""
+Local file-based registry for agent discovery.
+
+This module implements a simple JSON file-based registry for local development,
+replacing the need for external HTTPS registries or MongoDB.
+"""
+
+import json
+import os
+from datetime import datetime, timezone
+from typing import Optional, List, Dict
+
+
+class LocalRegistry:
+    """File-based registry for local agent discovery"""
+
+    def __init__(self, registry_file: str = ".nanda_registry.json"):
+        """
+        Initialize local registry.
+
+        Args:
+            registry_file: Path to registry JSON file (default: .nanda_registry.json)
+        """
+        self.registry_file = registry_file
+        self.agents = self._load()
+
+    def _load(self) -> Dict:
+        """Load registry from file"""
+        if os.path.exists(self.registry_file):
+            try:
+                with open(self.registry_file, 'r') as f:
+                    return json.load(f)
+            except (json.JSONDecodeError, IOError):
+                # If file is corrupted, start fresh
+                return {}
+        return {}
+
+    def _save(self):
+        """Save registry to file"""
+        with open(self.registry_file, 'w') as f:
+            json.dump(self.agents, f, indent=2, default=str)
+
+    def register(self, agent_id: str, agent_url: str) -> bool:
+        """
+        Register or update an agent.
+
+        Args:
+            agent_id: Unique agent identifier
+            agent_url: Full URL to agent (e.g., http://localhost:6000 or http://192.168.1.100:6002)
+
+        Returns:
+            True if successful
+        """
+        now = datetime.now(timezone.utc).isoformat()
+
+        if agent_id in self.agents:
+            # Update existing agent
+            self.agents[agent_id]["agent_url"] = agent_url
+            self.agents[agent_id]["last_seen"] = now
+        else:
+            # Register new agent
+            self.agents[agent_id] = {
+                "agent_url": agent_url,
+                "registered_at": now,
+                "last_seen": now
+            }
+
+        self._save()
+        return True
+
+    def lookup(self, agent_id: str) -> Optional[str]:
+        """
+        Get agent URL by ID.
+
+        Args:
+            agent_id: Agent identifier to look up
+
+        Returns:
+            Full URL to agent (e.g., http://localhost:6000) or None if not found
+        """
+        agent = self.agents.get(agent_id)
+        return agent["agent_url"] if agent else None
+
+    def list(self) -> List[Dict]:
+        """
+        List all registered agents.
+
+        Returns:
+            List of agent records with agent_id and metadata
+        """
+        return [
+            {"agent_id": aid, **data}
+            for aid, data in self.agents.items()
+        ]
+
+    def unregister(self, agent_id: str) -> bool:
+        """
+        Remove agent from registry.
+
+        Args:
+            agent_id: Agent identifier to remove
+
+        Returns:
+            True if agent was removed, False if not found
+        """
+        if agent_id in self.agents:
+            del self.agents[agent_id]
+            self._save()
+            return True
+        return False
+
+    def clear(self):
+        """
+        Clear all agents (for testing/reset).
+
+        Warning: This removes all registered agents from the registry.
+        """
+        self.agents = {}
+        self._save()

--- a/nanda_adapter/core/router.py
+++ b/nanda_adapter/core/router.py
@@ -1,0 +1,286 @@
+"""
+Message routing for NANDA agents.
+
+This module handles routing of messages between agents, including:
+- @agent_id routing (send to specific agent)
+- /command handling (/query, /help)
+- Integration with registry for agent lookup
+- Message improvement via pluggable logic
+- Loop prevention through depth tracking
+
+Example:
+    >>> from nanda_adapter.core.router import MessageRouter
+    >>> from nanda_adapter.core.registry import LocalRegistry
+    >>>
+    >>> registry = LocalRegistry()
+    >>> router = MessageRouter("agent_a", registry)
+    >>> response = router.route("@agent_b Hello!", "conv_001")
+"""
+
+from typing import Optional, Callable
+from .registry import LocalRegistry
+from .protocol import A2AMessage, format_a2a_message
+
+# Optional dependency - only needed if actually sending messages
+try:
+    import requests
+    from python_a2a import A2AClient, Message, MessageRole, TextContent
+    REQUESTS_AVAILABLE = True
+except ImportError:
+    REQUESTS_AVAILABLE = False
+
+
+class MessageRouter:
+    """
+    Routes messages to appropriate handlers.
+
+    The router is responsible for:
+    1. Parsing message format (@agent, /command, plain text)
+    2. Applying message improvement logic
+    3. Looking up agents in the registry
+    4. Sending messages via A2A protocol
+    5. Preventing infinite loops via depth tracking
+
+    Attributes:
+        agent_id: ID of the agent using this router
+        registry: Registry for agent lookup
+        improver: Optional function to improve/transform messages
+        claude_handler: Optional function to query Claude directly
+    """
+
+    def __init__(
+        self,
+        agent_id: str,
+        registry: LocalRegistry,
+        improver: Optional[Callable[[str], str]] = None,
+        claude_handler: Optional[Callable[[str], str]] = None
+    ):
+        """
+        Initialize message router.
+
+        Args:
+            agent_id: Unique identifier for this agent
+            registry: Registry instance for agent lookup
+            improver: Optional function to transform messages before sending
+            claude_handler: Optional function to query Claude API
+
+        Raises:
+            ValueError: If agent_id is empty or registry is None
+        """
+        if not agent_id:
+            raise ValueError("agent_id cannot be empty")
+        if registry is None:
+            raise ValueError("registry cannot be None")
+
+        self.agent_id = agent_id
+        self.registry = registry
+        self.improver = improver
+        self.claude_handler = claude_handler
+
+    def route(
+        self,
+        message: str,
+        conversation_id: str,
+        depth: int = 0
+    ) -> str:
+        """
+        Route a message to the appropriate handler.
+
+        Determines message type and delegates to the correct handler:
+        - @agent_id → _handle_agent_message (send to another agent)
+        - /command → _handle_command (execute command)
+        - plain text → _handle_default (query Claude or echo)
+
+        Args:
+            message: The message to route
+            conversation_id: Unique conversation identifier
+            depth: Current message depth (for loop prevention)
+
+        Returns:
+            Response string from the handler
+
+        Example:
+            >>> router.route("@agent_b Hello!", "conv_001")
+            '[agent_a] Message sent to agent_b'
+            >>> router.route("/help", "conv_001")
+            '[agent_a] Available commands: ...'
+            >>> router.route("What is 2+2?", "conv_001")
+            '[agent_a] 2+2 equals 4'
+        """
+        message = message.strip()
+
+        if message.startswith('@'):
+            return self._handle_agent_message(message, conversation_id, depth)
+        elif message.startswith('/'):
+            return self._handle_command(message, conversation_id)
+        else:
+            return self._handle_default(message, conversation_id)
+
+    def _handle_agent_message(
+        self,
+        message: str,
+        conversation_id: str,
+        depth: int
+    ) -> str:
+        """
+        Handle @agent_id messages (send to another agent).
+
+        Parses the target agent ID, applies message improvement, looks up
+        the agent in the registry, and sends via A2A protocol with depth
+        tracking for loop prevention.
+
+        Args:
+            message: Message in format "@agent_id message text"
+            conversation_id: Unique conversation identifier
+            depth: Current depth (incremented for response)
+
+        Returns:
+            Status message indicating success or error
+
+        Loop Prevention:
+            - Default max_depth is 1 (request-response only)
+            - If depth >= max_depth, message is not sent
+            - This prevents infinite agent-to-agent loops
+        """
+        # Check depth limit
+        if depth >= 1:  # MVP: Only allow request-response (max_depth=1)
+            return f"[{self.agent_id}] Maximum depth reached (depth={depth})"
+
+        # Parse @agent_id from message
+        parts = message.split(' ', 1)
+        if len(parts) < 2:
+            return f"[{self.agent_id}] Invalid format. Use '@agent_id message'"
+
+        target_agent = parts[0][1:]  # Remove @
+        message_text = parts[1]
+
+        # Apply improvement if configured
+        if self.improver:
+            try:
+                message_text = self.improver(message_text)
+            except Exception as e:
+                # Don't fail the whole message if improvement fails
+                print(f"Warning: Message improvement failed: {e}")
+
+        # Lookup target agent
+        target_url = self.registry.lookup(target_agent)
+        if not target_url:
+            return f"[{self.agent_id}] Agent '{target_agent}' not found in registry"
+
+        # Create A2A message
+        a2a_msg = A2AMessage(
+            from_agent=self.agent_id,
+            to_agent=target_agent,
+            message=message_text,
+            conversation_id=conversation_id,
+            depth=depth,
+            max_depth=1,  # MVP: Only request-response
+            message_type="query"
+        )
+
+        formatted = format_a2a_message(a2a_msg)
+
+        # Send via HTTP POST (python-a2a client)
+        try:
+            if not REQUESTS_AVAILABLE:
+                return f"[{self.agent_id}] Error: requests library not available"
+
+            # Ensure URL has /a2a path
+            if not target_url.endswith('/a2a'):
+                target_url = f"{target_url}/a2a"
+
+            client = A2AClient(target_url, timeout=30)
+            response = client.send_message(
+                Message(
+                    role=MessageRole.USER,
+                    content=TextContent(text=formatted),
+                    conversation_id=conversation_id
+                )
+            )
+
+            return f"[{self.agent_id}] Message sent to {target_agent}"
+
+        except Exception as e:
+            return f"[{self.agent_id}] Error sending to {target_agent}: {str(e)}"
+
+    def _handle_command(self, message: str, conversation_id: str) -> str:
+        """
+        Handle /command messages.
+
+        Supported commands:
+        - /help: Show available commands
+        - /query <text>: Query Claude directly (no A2A routing)
+
+        Args:
+            message: Message starting with /
+            conversation_id: Unique conversation identifier
+
+        Returns:
+            Command response or error message
+        """
+        parts = message.split(' ', 1)
+        command = parts[0][1:]  # Remove /
+
+        if command == 'help':
+            return self._get_help_text()
+        elif command == 'query':
+            if len(parts) < 2:
+                return f"[{self.agent_id}] Usage: /query <question>"
+            return self._query_claude(parts[1])
+        else:
+            return f"[{self.agent_id}] Unknown command '{command}'. Try /help"
+
+    def _handle_default(self, message: str, conversation_id: str) -> str:
+        """
+        Handle plain text messages (no @ or /).
+
+        Default behavior is to query Claude if handler is configured,
+        otherwise echo the message back.
+
+        Args:
+            message: Plain text message
+            conversation_id: Unique conversation identifier
+
+        Returns:
+            Claude's response or echo
+        """
+        return self._query_claude(message)
+
+    def _query_claude(self, query: str) -> str:
+        """
+        Query Claude API directly (no A2A routing).
+
+        Uses the claude_handler function if provided, otherwise returns
+        a message indicating Claude is not configured.
+
+        Args:
+            query: Question or prompt for Claude
+
+        Returns:
+            Claude's response or error message
+        """
+        if not self.claude_handler:
+            return f"[{self.agent_id}] Claude handler not configured"
+
+        try:
+            response = self.claude_handler(query)
+            return f"[{self.agent_id}] {response}"
+        except Exception as e:
+            return f"[{self.agent_id}] Error querying Claude: {str(e)}"
+
+    def _get_help_text(self) -> str:
+        """
+        Generate help text listing available commands.
+
+        Returns:
+            Formatted help text
+        """
+        return f"""[{self.agent_id}] Available commands:
+  /help - Show this message
+  /query <question> - Ask Claude directly (no agent routing)
+  @<agent_id> <message> - Send message to another agent
+
+Examples:
+  @agent_b What is the capital of France?
+  /query Explain the A2A protocol
+  /help"""

--- a/nanda_adapter/simple.py
+++ b/nanda_adapter/simple.py
@@ -1,0 +1,366 @@
+"""
+SimpleNANDA - Minimal entry point for local agent development.
+
+This module provides a streamlined interface for creating NANDA agents
+without requiring external registries, SSL certificates, or complex configuration.
+
+Perfect for:
+- Local development and testing
+- Multi-agent experimentation
+- Learning the A2A protocol
+- Rapid prototyping
+
+Example:
+    >>> from nanda_adapter.simple import SimpleNANDA
+    >>>
+    >>> # Create agent with Claude
+    >>> agent = SimpleNANDA('my_agent', 'localhost:6000')
+    >>> agent.start()
+    >>>
+    >>> # Create agent with custom logic (no Claude needed)
+    >>> def uppercase(text): return text.upper()
+    >>> agent = SimpleNANDA(
+    ...     'simple_agent',
+    ...     'localhost:6002',
+    ...     improvement_logic=uppercase,
+    ...     require_anthropic=False
+    ... )
+    >>> agent.start()
+"""
+
+import os
+from typing import Optional, Callable
+
+from .core.registry import LocalRegistry
+from .core.router import MessageRouter
+from .core.protocol import parse_a2a_message, is_a2a_message
+from .core.logger import ConversationLogger
+
+# Optional dependencies
+try:
+    from anthropic import Anthropic
+    ANTHROPIC_AVAILABLE = True
+except ImportError:
+    ANTHROPIC_AVAILABLE = False
+
+try:
+    from python_a2a import A2AServer, Message, MessageRole, TextContent, run_server
+    A2A_AVAILABLE = True
+except ImportError:
+    A2A_AVAILABLE = False
+
+
+class SimpleNANDA:
+    """
+    Minimal NANDA adapter for local development.
+
+    SimpleNANDA provides a streamlined interface for creating agents that
+    communicate via the A2A protocol, with file-based registry and optional
+    Claude integration.
+
+    Attributes:
+        agent_id: Unique identifier for this agent
+        host: Host string in format "hostname:port" (e.g., "localhost:6000")
+        hostname: Extracted hostname from host parameter
+        port: Extracted port number from host parameter
+        registry: LocalRegistry instance for agent discovery
+        router: MessageRouter for handling messages
+        logger: ConversationLogger for JSONL logging
+        improvement_logic: Optional function to transform outgoing messages
+
+    Loop Prevention:
+        - Messages include depth tracking
+        - Default max_depth=1 (request-response only)
+        - Prevents infinite agent-to-agent loops
+
+    Example:
+        >>> agent = SimpleNANDA('agent_a', 'localhost:6000')
+        >>> agent.start()  # Starts server, blocks until interrupted
+    """
+
+    def __init__(
+        self,
+        agent_id: str,
+        host: str = "localhost:6000",
+        improvement_logic: Optional[Callable[[str], str]] = None,
+        anthropic_api_key: Optional[str] = None,
+        require_anthropic: bool = True,
+        registry: Optional[LocalRegistry] = None,
+        log_dir: str = "./logs"
+    ):
+        """
+        Initialize SimpleNANDA agent.
+
+        Args:
+            agent_id: Unique identifier for this agent
+            host: Host in "hostname:port" format (default: "localhost:6000")
+                  Supports: "localhost:6000", "192.168.1.100:6002", etc.
+            improvement_logic: Optional function to transform messages
+            anthropic_api_key: Claude API key (or set ANTHROPIC_API_KEY env var)
+            require_anthropic: Whether Claude is required (default: True)
+            registry: Custom registry instance (default: LocalRegistry())
+            log_dir: Base directory for conversation logs (default: "./logs")
+
+        Raises:
+            ValueError: If agent_id is empty
+            ValueError: If require_anthropic=True but no API key provided
+            ValueError: If host format is invalid
+            ImportError: If required dependencies are missing
+
+        Example:
+            >>> # With Claude (requires ANTHROPIC_API_KEY)
+            >>> agent = SimpleNANDA('agent_a', 'localhost:6000')
+            >>>
+            >>> # Without Claude (custom logic only)
+            >>> def my_logic(text): return text.upper()
+            >>> agent = SimpleNANDA(
+            ...     'agent_a',
+            ...     'localhost:6000',
+            ...     improvement_logic=my_logic,
+            ...     require_anthropic=False
+            ... )
+            >>>
+            >>> # On specific host/IP
+            >>> agent = SimpleNANDA('agent_a', '192.168.1.100:6000')
+        """
+        if not agent_id:
+            raise ValueError("agent_id cannot be empty")
+
+        if not A2A_AVAILABLE:
+            raise ImportError(
+                "python-a2a library is required. Install with: pip install python-a2a"
+            )
+
+        self.agent_id = agent_id
+        self.host = host
+        self.improvement_logic = improvement_logic
+
+        # Parse host:port
+        self._parse_host(host)
+
+        # Initialize registry (use provided or create new)
+        self.registry = registry or LocalRegistry()
+
+        # Lazy-initialize Anthropic client (Bug fix - see docs/BUGS_AND_ISSUES.md)
+        self._anthropic_client = None
+        if require_anthropic:
+            if not ANTHROPIC_AVAILABLE:
+                raise ImportError(
+                    "anthropic library is required for Claude integration. "
+                    "Install with: pip install anthropic\n"
+                    "Or set require_anthropic=False to disable Claude."
+                )
+
+            self.anthropic_api_key = anthropic_api_key or os.getenv("ANTHROPIC_API_KEY")
+            if not self.anthropic_api_key:
+                raise ValueError(
+                    "ANTHROPIC_API_KEY required for Claude integration.\n"
+                    "Set via environment or pass anthropic_api_key parameter.\n"
+                    "To disable Claude: SimpleNANDA(..., require_anthropic=False)"
+                )
+        else:
+            self.anthropic_api_key = None
+
+        # Initialize logger
+        self.logger = ConversationLogger(agent_id, log_dir)
+
+        # Initialize router
+        self.router = MessageRouter(
+            agent_id=agent_id,
+            registry=self.registry,
+            improver=improvement_logic,
+            claude_handler=self._call_claude if require_anthropic else None
+        )
+
+        # Register with registry
+        agent_url = f"http://{self.hostname}:{self.port}"
+        self.registry.register(agent_id, agent_url)
+
+        print(f"✓ Agent '{agent_id}' initialized at {agent_url}")
+        print(f"✓ Registry: {self.registry.registry_file}")
+        print(f"✓ Logs: {self.logger.agent_log_dir}")
+
+    def _parse_host(self, host: str) -> None:
+        """
+        Parse host:port string.
+
+        Args:
+            host: String in format "hostname:port"
+
+        Raises:
+            ValueError: If format is invalid or port is not a number
+
+        Example:
+            >>> agent._parse_host("localhost:6000")
+            >>> agent.hostname
+            'localhost'
+            >>> agent.port
+            6000
+        """
+        if ':' not in host:
+            raise ValueError(
+                f"Invalid host format '{host}'. Expected 'hostname:port' "
+                f"(e.g., 'localhost:6000' or '192.168.1.100:6002')"
+            )
+
+        hostname, port_str = host.rsplit(':', 1)
+
+        if not hostname:
+            raise ValueError(f"Hostname cannot be empty in '{host}'")
+
+        try:
+            port = int(port_str)
+        except ValueError:
+            raise ValueError(f"Invalid port '{port_str}' in '{host}'. Must be a number.")
+
+        if port < 1 or port > 65535:
+            raise ValueError(f"Port {port} out of range (1-65535)")
+
+        self.hostname = hostname
+        self.port = port
+
+    @property
+    def anthropic(self) -> Optional[Anthropic]:
+        """
+        Lazy-load Anthropic client (Bug fix).
+
+        Returns:
+            Anthropic client instance or None if not configured
+
+        Note:
+            Client is only created when first accessed, not at initialization.
+            This allows agents to work without an API key if they don't use Claude.
+        """
+        if self._anthropic_client is None and self.anthropic_api_key:
+            self._anthropic_client = Anthropic(api_key=self.anthropic_api_key)
+        return self._anthropic_client
+
+    def _call_claude(self, prompt: str) -> str:
+        """
+        Call Claude API.
+
+        Args:
+            prompt: Question or prompt for Claude
+
+        Returns:
+            Claude's response text
+
+        Raises:
+            Exception: If API call fails (caught by router)
+        """
+        if not self.anthropic:
+            return f"Claude not configured (require_anthropic=False)"
+
+        response = self.anthropic.messages.create(
+            model="claude-3-5-sonnet-20241022",
+            max_tokens=1024,
+            messages=[{"role": "user", "content": prompt}]
+        )
+        return response.content[0].text
+
+    def start(self) -> None:
+        """
+        Start the A2A server.
+
+        Starts the agent server and blocks until interrupted (Ctrl+C).
+        The server listens on the configured host:port and handles
+        incoming A2A messages.
+
+        Loop Prevention:
+            - Incoming messages with depth >= max_depth are logged but not responded to
+            - This prevents infinite agent-to-agent loops
+            - Default max_depth=1 allows only request-response pattern
+
+        Raises:
+            KeyboardInterrupt: When server is stopped with Ctrl+C
+
+        Example:
+            >>> agent = SimpleNANDA('agent_a', 'localhost:6000')
+            >>> agent.start()  # Blocks until Ctrl+C
+            🚀 Agent 'agent_a' starting on localhost:6000
+            📍 Registered at http://localhost:6000
+            ^C
+            Shutting down...
+        """
+        class AgentServer(A2AServer):
+            def __init__(self, parent):
+                super().__init__()
+                self.parent = parent
+
+            def handle_message(self, msg: Message) -> Message:
+                conversation_id = msg.conversation_id or "default"
+                user_text = msg.content.text
+
+                # Log incoming
+                self.parent.logger.log(conversation_id, "incoming", user_text)
+
+                # Check if A2A external message
+                if is_a2a_message(user_text):
+                    a2a_msg = parse_a2a_message(user_text)
+                    if a2a_msg:
+                        # Set conversation_id from context
+                        a2a_msg.conversation_id = conversation_id
+
+                        # Check if we should respond (depth limit)
+                        if a2a_msg.depth >= a2a_msg.max_depth:
+                            # Just log, don't respond (loop prevention)
+                            response_text = (
+                                f"[{self.parent.agent_id}] Response logged "
+                                f"(max depth {a2a_msg.max_depth} reached)"
+                            )
+                            self.parent.logger.log(
+                                conversation_id,
+                                "response_logged",
+                                a2a_msg.message,
+                                metadata={
+                                    "from_agent": a2a_msg.from_agent,
+                                    "depth": a2a_msg.depth,
+                                    "max_depth": a2a_msg.max_depth
+                                }
+                            )
+                        else:
+                            # Generate response via Claude
+                            if self.parent.router.claude_handler:
+                                try:
+                                    claude_response = self.parent._call_claude(a2a_msg.message)
+
+                                    # Send response back (depth + 1)
+                                    response_text = self.parent.router.route(
+                                        f"@{a2a_msg.from_agent} {claude_response}",
+                                        conversation_id,
+                                        depth=a2a_msg.depth + 1
+                                    )
+                                except Exception as e:
+                                    response_text = f"[{self.parent.agent_id}] Error: {str(e)}"
+                            else:
+                                response_text = (
+                                    f"[{self.parent.agent_id}] Received from "
+                                    f"{a2a_msg.from_agent}: {a2a_msg.message}"
+                                )
+                    else:
+                        response_text = "Invalid A2A message format"
+                else:
+                    # Regular message, route it
+                    response_text = self.parent.router.route(user_text, conversation_id)
+
+                # Log outgoing
+                self.parent.logger.log(conversation_id, "outgoing", response_text)
+
+                return Message(
+                    role=MessageRole.AGENT,
+                    content=TextContent(text=response_text),
+                    parent_message_id=msg.message_id,
+                    conversation_id=conversation_id
+                )
+
+        server = AgentServer(self)
+        print(f"\n🚀 Agent '{self.agent_id}' starting on {self.hostname}:{self.port}")
+        print(f"📍 Registered at http://{self.hostname}:{self.port}")
+        print(f"📝 Logs: {self.logger.agent_log_dir}")
+        print(f"\nPress Ctrl+C to stop\n")
+
+        try:
+            run_server(server, host="0.0.0.0", port=self.port)
+        except KeyboardInterrupt:
+            print("\n\nShutting down...")
+            print(f"✓ Agent '{self.agent_id}' stopped")

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1,0 +1,271 @@
+"""
+Unit tests for ConversationLogger.
+
+Tests JSONL logging functionality including writing, reading,
+and managing conversation logs.
+"""
+
+import pytest
+import json
+from pathlib import Path
+from nanda_adapter.core.logger import ConversationLogger
+
+
+@pytest.fixture
+def temp_log_dir(tmp_path):
+    """Provide a temporary log directory"""
+    return str(tmp_path / "test_logs")
+
+
+@pytest.fixture
+def logger(temp_log_dir):
+    """Provide a fresh ConversationLogger instance"""
+    return ConversationLogger("agent_test", temp_log_dir)
+
+
+class TestConversationLoggerInit:
+    """Tests for logger initialization."""
+
+    def test_create_logger(self, temp_log_dir):
+        """Test creating a logger creates directory structure."""
+        logger = ConversationLogger("agent_a", temp_log_dir)
+        assert logger.agent_id == "agent_a"
+        assert logger.agent_log_dir.exists()
+        assert logger.agent_log_dir.name == "agent_agent_a"
+
+    def test_empty_agent_id_raises_error(self, temp_log_dir):
+        """Test that empty agent_id raises ValueError."""
+        with pytest.raises(ValueError, match="agent_id cannot be empty"):
+            ConversationLogger("", temp_log_dir)
+
+    def test_multiple_loggers_same_directory(self, temp_log_dir):
+        """Test multiple loggers can share base directory."""
+        logger_a = ConversationLogger("agent_a", temp_log_dir)
+        logger_b = ConversationLogger("agent_b", temp_log_dir)
+
+        assert logger_a.agent_log_dir != logger_b.agent_log_dir
+        assert logger_a.agent_log_dir.exists()
+        assert logger_b.agent_log_dir.exists()
+
+
+class TestLogging:
+    """Tests for logging messages."""
+
+    def test_log_simple_message(self, logger):
+        """Test logging a simple message."""
+        logger.log("conv_001", "incoming", "Hello world")
+
+        log_file = logger.get_conversation_log_path("conv_001")
+        assert log_file.exists()
+
+        with open(log_file, 'r') as f:
+            entry = json.loads(f.readline())
+
+        assert entry["agent_id"] == "agent_test"
+        assert entry["conversation_id"] == "conv_001"
+        assert entry["source"] == "incoming"
+        assert entry["message"] == "Hello world"
+        assert "timestamp" in entry
+
+    def test_log_with_metadata(self, logger):
+        """Test logging with additional metadata."""
+        logger.log(
+            "conv_001",
+            "incoming",
+            "Hello",
+            metadata={"depth": 0, "from_agent": "agent_b"}
+        )
+
+        entries = logger.read_conversation("conv_001")
+        assert len(entries) == 1
+        assert "metadata" in entries[0]
+        assert entries[0]["metadata"]["depth"] == 0
+        assert entries[0]["metadata"]["from_agent"] == "agent_b"
+
+    def test_log_multiple_messages(self, logger):
+        """Test logging multiple messages to same conversation."""
+        logger.log("conv_001", "incoming", "Message 1")
+        logger.log("conv_001", "outgoing", "Message 2")
+        logger.log("conv_001", "incoming", "Message 3")
+
+        entries = logger.read_conversation("conv_001")
+        assert len(entries) == 3
+        assert entries[0]["message"] == "Message 1"
+        assert entries[1]["message"] == "Message 2"
+        assert entries[2]["message"] == "Message 3"
+
+    def test_log_multiline_message(self, logger):
+        """Test logging message with newlines."""
+        multiline = "Line 1\nLine 2\nLine 3"
+        logger.log("conv_001", "incoming", multiline)
+
+        entries = logger.read_conversation("conv_001")
+        assert entries[0]["message"] == multiline
+
+    def test_log_unicode_message(self, logger):
+        """Test logging message with unicode characters."""
+        unicode_msg = "Hello 你好 🎉 café"
+        logger.log("conv_001", "incoming", unicode_msg)
+
+        entries = logger.read_conversation("conv_001")
+        assert entries[0]["message"] == unicode_msg
+
+    def test_log_different_conversations(self, logger):
+        """Test logging to different conversations."""
+        logger.log("conv_001", "incoming", "Conversation 1")
+        logger.log("conv_002", "incoming", "Conversation 2")
+
+        entries_1 = logger.read_conversation("conv_001")
+        entries_2 = logger.read_conversation("conv_002")
+
+        assert len(entries_1) == 1
+        assert len(entries_2) == 1
+        assert entries_1[0]["message"] == "Conversation 1"
+        assert entries_2[0]["message"] == "Conversation 2"
+
+
+class TestReadConversation:
+    """Tests for reading conversation logs."""
+
+    def test_read_nonexistent_conversation(self, logger):
+        """Test reading conversation that doesn't exist."""
+        entries = logger.read_conversation("nonexistent")
+        assert entries == []
+
+    def test_read_empty_conversation(self, logger, temp_log_dir):
+        """Test reading conversation with empty log file."""
+        # Create empty file
+        log_file = logger.get_conversation_log_path("conv_001")
+        log_file.touch()
+
+        entries = logger.read_conversation("conv_001")
+        assert entries == []
+
+    def test_read_preserves_order(self, logger):
+        """Test that reading preserves chronological order."""
+        for i in range(10):
+            logger.log("conv_001", "test", f"Message {i}")
+
+        entries = logger.read_conversation("conv_001")
+        assert len(entries) == 10
+        for i, entry in enumerate(entries):
+            assert entry["message"] == f"Message {i}"
+
+
+class TestGetConversationLogPath:
+    """Tests for getting log file paths."""
+
+    def test_get_log_path(self, logger):
+        """Test getting conversation log path."""
+        path = logger.get_conversation_log_path("conv_001")
+        assert path.name == "conversation_conv_001.jsonl"
+        assert "agent_test" in str(path)
+
+    def test_get_log_path_different_conversations(self, logger):
+        """Test that different conversations have different paths."""
+        path_1 = logger.get_conversation_log_path("conv_001")
+        path_2 = logger.get_conversation_log_path("conv_002")
+        assert path_1 != path_2
+
+
+class TestListConversations:
+    """Tests for listing conversations."""
+
+    def test_list_no_conversations(self, logger):
+        """Test listing when no conversations exist."""
+        conversations = logger.list_conversations()
+        assert conversations == []
+
+    def test_list_single_conversation(self, logger):
+        """Test listing single conversation."""
+        logger.log("conv_001", "incoming", "Hello")
+        conversations = logger.list_conversations()
+        assert conversations == ["conv_001"]
+
+    def test_list_multiple_conversations(self, logger):
+        """Test listing multiple conversations."""
+        logger.log("conv_001", "incoming", "Hello")
+        logger.log("conv_002", "incoming", "Hi")
+        logger.log("conv_003", "incoming", "Hey")
+
+        conversations = logger.list_conversations()
+        assert len(conversations) == 3
+        assert "conv_001" in conversations
+        assert "conv_002" in conversations
+        assert "conv_003" in conversations
+
+    def test_list_conversations_sorted(self, logger):
+        """Test that conversations are returned sorted."""
+        logger.log("conv_003", "incoming", "C")
+        logger.log("conv_001", "incoming", "A")
+        logger.log("conv_002", "incoming", "B")
+
+        conversations = logger.list_conversations()
+        assert conversations == ["conv_001", "conv_002", "conv_003"]
+
+
+class TestClearConversation:
+    """Tests for clearing conversation logs."""
+
+    def test_clear_existing_conversation(self, logger):
+        """Test clearing a conversation that exists."""
+        logger.log("conv_001", "incoming", "Hello")
+        assert logger.get_conversation_log_path("conv_001").exists()
+
+        result = logger.clear_conversation("conv_001")
+        assert result is True
+        assert not logger.get_conversation_log_path("conv_001").exists()
+
+    def test_clear_nonexistent_conversation(self, logger):
+        """Test clearing conversation that doesn't exist."""
+        result = logger.clear_conversation("nonexistent")
+        assert result is False
+
+    def test_clear_removes_from_list(self, logger):
+        """Test that cleared conversation is removed from list."""
+        logger.log("conv_001", "incoming", "Hello")
+        logger.log("conv_002", "incoming", "Hi")
+
+        assert "conv_001" in logger.list_conversations()
+
+        logger.clear_conversation("conv_001")
+        conversations = logger.list_conversations()
+
+        assert "conv_001" not in conversations
+        assert "conv_002" in conversations
+
+
+class TestJSONLFormat:
+    """Tests for JSONL format compliance."""
+
+    def test_one_json_per_line(self, logger):
+        """Test that each log entry is on its own line."""
+        logger.log("conv_001", "incoming", "Message 1")
+        logger.log("conv_001", "incoming", "Message 2")
+        logger.log("conv_001", "incoming", "Message 3")
+
+        log_file = logger.get_conversation_log_path("conv_001")
+        with open(log_file, 'r') as f:
+            lines = f.readlines()
+
+        assert len(lines) == 3
+        for line in lines:
+            # Each line should be valid JSON
+            entry = json.loads(line)
+            assert "message" in entry
+
+    def test_jsonl_parseable_with_standard_tools(self, logger):
+        """Test that JSONL can be parsed line by line."""
+        logger.log("conv_001", "incoming", "Message 1")
+        logger.log("conv_001", "outgoing", "Message 2")
+
+        log_file = logger.get_conversation_log_path("conv_001")
+
+        # Simulate reading with standard tools (line by line)
+        messages = []
+        with open(log_file, 'r') as f:
+            for line in f:
+                entry = json.loads(line)
+                messages.append(entry["message"])
+
+        assert messages == ["Message 1", "Message 2"]

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -1,0 +1,382 @@
+"""
+Unit tests for A2A Protocol module.
+
+Tests message formatting, parsing, validation, and round-trip operations
+for the Agent-to-Agent communication protocol.
+"""
+
+import pytest
+from nanda_adapter.core.protocol import (
+    A2AMessage,
+    format_a2a_message,
+    parse_a2a_message,
+    is_a2a_message
+)
+
+
+class TestA2AMessage:
+    """Tests for A2AMessage dataclass validation."""
+
+    def test_create_valid_message(self):
+        """Test creating a valid A2A message."""
+        msg = A2AMessage(
+            from_agent="agent_a",
+            to_agent="agent_b",
+            message="Hello",
+            conversation_id="conv_001"
+        )
+        assert msg.from_agent == "agent_a"
+        assert msg.to_agent == "agent_b"
+        assert msg.message == "Hello"
+        assert msg.conversation_id == "conv_001"
+        assert msg.depth == 0  # Default
+        assert msg.max_depth == 1  # Default
+        assert msg.message_type == "query"  # Default
+
+    def test_create_with_custom_depth(self):
+        """Test creating message with custom depth values."""
+        msg = A2AMessage(
+            from_agent="agent_a",
+            to_agent="agent_b",
+            message="Response",
+            conversation_id="conv_001",
+            depth=1,
+            max_depth=2,
+            message_type="response"
+        )
+        assert msg.depth == 1
+        assert msg.max_depth == 2
+        assert msg.message_type == "response"
+
+    def test_empty_from_agent_raises_error(self):
+        """Test that empty from_agent raises ValueError."""
+        with pytest.raises(ValueError, match="from_agent cannot be empty"):
+            A2AMessage(
+                from_agent="",
+                to_agent="agent_b",
+                message="Hello",
+                conversation_id="conv_001"
+            )
+
+    def test_empty_to_agent_raises_error(self):
+        """Test that empty to_agent raises ValueError."""
+        with pytest.raises(ValueError, match="to_agent cannot be empty"):
+            A2AMessage(
+                from_agent="agent_a",
+                to_agent="",
+                message="Hello",
+                conversation_id="conv_001"
+            )
+
+    def test_empty_message_raises_error(self):
+        """Test that empty message raises ValueError."""
+        with pytest.raises(ValueError, match="message cannot be empty"):
+            A2AMessage(
+                from_agent="agent_a",
+                to_agent="agent_b",
+                message="",
+                conversation_id="conv_001"
+            )
+
+    def test_empty_conversation_id_allowed(self):
+        """Test that empty conversation_id is allowed (set by caller later)."""
+        msg = A2AMessage(
+            from_agent="agent_a",
+            to_agent="agent_b",
+            message="Hello",
+            conversation_id=""
+        )
+        assert msg.conversation_id == ""
+
+    def test_negative_depth_raises_error(self):
+        """Test that negative depth raises ValueError."""
+        with pytest.raises(ValueError, match="depth must be non-negative"):
+            A2AMessage(
+                from_agent="agent_a",
+                to_agent="agent_b",
+                message="Hello",
+                conversation_id="conv_001",
+                depth=-1
+            )
+
+    def test_negative_max_depth_raises_error(self):
+        """Test that negative max_depth raises ValueError."""
+        with pytest.raises(ValueError, match="max_depth must be non-negative"):
+            A2AMessage(
+                from_agent="agent_a",
+                to_agent="agent_b",
+                message="Hello",
+                conversation_id="conv_001",
+                max_depth=-1
+            )
+
+    def test_invalid_message_type_raises_error(self):
+        """Test that invalid message_type raises ValueError."""
+        with pytest.raises(ValueError, match="message_type must be"):
+            A2AMessage(
+                from_agent="agent_a",
+                to_agent="agent_b",
+                message="Hello",
+                conversation_id="conv_001",
+                message_type="invalid"
+            )
+
+
+class TestFormatA2AMessage:
+    """Tests for format_a2a_message function."""
+
+    def test_format_basic_message(self):
+        """Test formatting a basic message."""
+        msg = A2AMessage(
+            from_agent="agent_a",
+            to_agent="agent_b",
+            message="Hello",
+            conversation_id="conv_001"
+        )
+        formatted = format_a2a_message(msg)
+
+        assert "__EXTERNAL_MESSAGE__" in formatted
+        assert "__FROM_AGENT__agent_a" in formatted
+        assert "__TO_AGENT__agent_b" in formatted
+        assert "__MESSAGE_TYPE__query" in formatted
+        assert "__DEPTH__0" in formatted
+        assert "__MAX_DEPTH__1" in formatted
+        assert "__MESSAGE_START__" in formatted
+        assert "Hello" in formatted
+        assert "__MESSAGE_END__" in formatted
+
+    def test_format_with_custom_depth(self):
+        """Test formatting message with custom depth values."""
+        msg = A2AMessage(
+            from_agent="agent_a",
+            to_agent="agent_b",
+            message="Response",
+            conversation_id="conv_001",
+            depth=2,
+            max_depth=5,
+            message_type="response"
+        )
+        formatted = format_a2a_message(msg)
+
+        assert "__DEPTH__2" in formatted
+        assert "__MAX_DEPTH__5" in formatted
+        assert "__MESSAGE_TYPE__response" in formatted
+
+    def test_format_multiline_message(self):
+        """Test formatting message with multiple lines."""
+        msg = A2AMessage(
+            from_agent="agent_a",
+            to_agent="agent_b",
+            message="Line 1\nLine 2\nLine 3",
+            conversation_id="conv_001"
+        )
+        formatted = format_a2a_message(msg)
+
+        assert "Line 1" in formatted
+        assert "Line 2" in formatted
+        assert "Line 3" in formatted
+
+
+class TestParseA2AMessage:
+    """Tests for parse_a2a_message function."""
+
+    def test_parse_formatted_message(self):
+        """Test parsing a properly formatted message."""
+        original = A2AMessage(
+            from_agent="agent_a",
+            to_agent="agent_b",
+            message="Hello",
+            conversation_id="conv_001"
+        )
+        formatted = format_a2a_message(original)
+        parsed = parse_a2a_message(formatted)
+
+        assert parsed is not None
+        assert parsed.from_agent == "agent_a"
+        assert parsed.to_agent == "agent_b"
+        assert parsed.message == "Hello"
+        assert parsed.depth == 0
+        assert parsed.max_depth == 1
+        assert parsed.message_type == "query"
+
+    def test_parse_with_custom_depth(self):
+        """Test parsing message with custom depth values."""
+        original = A2AMessage(
+            from_agent="agent_a",
+            to_agent="agent_b",
+            message="Response",
+            conversation_id="conv_001",
+            depth=3,
+            max_depth=10,
+            message_type="response"
+        )
+        formatted = format_a2a_message(original)
+        parsed = parse_a2a_message(formatted)
+
+        assert parsed.depth == 3
+        assert parsed.max_depth == 10
+        assert parsed.message_type == "response"
+
+    def test_parse_multiline_message(self):
+        """Test parsing message with multiple lines."""
+        original = A2AMessage(
+            from_agent="agent_a",
+            to_agent="agent_b",
+            message="Line 1\nLine 2\nLine 3",
+            conversation_id="conv_001"
+        )
+        formatted = format_a2a_message(original)
+        parsed = parse_a2a_message(formatted)
+
+        assert parsed.message == "Line 1\nLine 2\nLine 3"
+
+    def test_parse_non_a2a_message_returns_none(self):
+        """Test that non-A2A messages return None."""
+        result = parse_a2a_message("Hello world")
+        assert result is None
+
+    def test_parse_empty_string_returns_none(self):
+        """Test that empty string returns None."""
+        result = parse_a2a_message("")
+        assert result is None
+
+    def test_parse_missing_from_agent_returns_none(self):
+        """Test that message missing from_agent returns None."""
+        incomplete = """__EXTERNAL_MESSAGE__
+__TO_AGENT__agent_b
+__MESSAGE_START__
+Hello
+__MESSAGE_END__"""
+        result = parse_a2a_message(incomplete)
+        assert result is None
+
+    def test_parse_missing_to_agent_returns_none(self):
+        """Test that message missing to_agent returns None."""
+        incomplete = """__EXTERNAL_MESSAGE__
+__FROM_AGENT__agent_a
+__MESSAGE_START__
+Hello
+__MESSAGE_END__"""
+        result = parse_a2a_message(incomplete)
+        assert result is None
+
+    def test_parse_missing_message_content_returns_none(self):
+        """Test that message without content returns None."""
+        incomplete = """__EXTERNAL_MESSAGE__
+__FROM_AGENT__agent_a
+__TO_AGENT__agent_b
+__MESSAGE_START__
+__MESSAGE_END__"""
+        result = parse_a2a_message(incomplete)
+        assert result is None
+
+    def test_parse_invalid_depth_uses_default(self):
+        """Test that invalid depth value falls back to default."""
+        malformed = """__EXTERNAL_MESSAGE__
+__FROM_AGENT__agent_a
+__TO_AGENT__agent_b
+__DEPTH__invalid
+__MESSAGE_START__
+Hello
+__MESSAGE_END__"""
+        parsed = parse_a2a_message(malformed)
+        assert parsed is not None
+        assert parsed.depth == 0  # Default
+
+    def test_parse_invalid_max_depth_uses_default(self):
+        """Test that invalid max_depth value falls back to default."""
+        malformed = """__EXTERNAL_MESSAGE__
+__FROM_AGENT__agent_a
+__TO_AGENT__agent_b
+__MAX_DEPTH__invalid
+__MESSAGE_START__
+Hello
+__MESSAGE_END__"""
+        parsed = parse_a2a_message(malformed)
+        assert parsed is not None
+        assert parsed.max_depth == 1  # Default
+
+
+class TestIsA2AMessage:
+    """Tests for is_a2a_message function."""
+
+    def test_valid_a2a_message(self):
+        """Test that valid A2A message is detected."""
+        msg = A2AMessage(
+            from_agent="agent_a",
+            to_agent="agent_b",
+            message="Hello",
+            conversation_id="conv_001"
+        )
+        formatted = format_a2a_message(msg)
+        assert is_a2a_message(formatted) is True
+
+    def test_non_a2a_message(self):
+        """Test that non-A2A message is rejected."""
+        assert is_a2a_message("Hello world") is False
+
+    def test_empty_string(self):
+        """Test that empty string is rejected."""
+        assert is_a2a_message("") is False
+
+    def test_whitespace_only(self):
+        """Test that whitespace-only string is rejected."""
+        assert is_a2a_message("   \n  \t  ") is False
+
+    def test_marker_with_leading_whitespace(self):
+        """Test that marker with leading whitespace is detected."""
+        assert is_a2a_message("  \n  __EXTERNAL_MESSAGE__\n...") is True
+
+
+class TestRoundTrip:
+    """Tests for format → parse round-trip operations."""
+
+    def test_round_trip_basic(self):
+        """Test that format → parse preserves all fields."""
+        original = A2AMessage(
+            from_agent="agent_a",
+            to_agent="agent_b",
+            message="Test message",
+            conversation_id="conv_001",
+            depth=2,
+            max_depth=5,
+            message_type="response"
+        )
+
+        formatted = format_a2a_message(original)
+        parsed = parse_a2a_message(formatted)
+
+        assert parsed.from_agent == original.from_agent
+        assert parsed.to_agent == original.to_agent
+        assert parsed.message == original.message
+        assert parsed.depth == original.depth
+        assert parsed.max_depth == original.max_depth
+        assert parsed.message_type == original.message_type
+
+    def test_round_trip_with_special_characters(self):
+        """Test round-trip with special characters in message."""
+        original = A2AMessage(
+            from_agent="agent_a",
+            to_agent="agent_b",
+            message="Special chars: @#$%^&*() \"quotes\" 'apostrophes'",
+            conversation_id="conv_001"
+        )
+
+        formatted = format_a2a_message(original)
+        parsed = parse_a2a_message(formatted)
+
+        assert parsed.message == original.message
+
+    def test_round_trip_with_unicode(self):
+        """Test round-trip with unicode characters."""
+        original = A2AMessage(
+            from_agent="agent_a",
+            to_agent="agent_b",
+            message="Unicode: 你好 🎉 café",
+            conversation_id="conv_001"
+        )
+
+        formatted = format_a2a_message(original)
+        parsed = parse_a2a_message(formatted)
+
+        assert parsed.message == original.message

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -1,0 +1,185 @@
+"""
+Unit tests for LocalRegistry.
+
+Tests file-based registry operations including registration, lookup,
+listing, unregistration, and persistence.
+"""
+
+import pytest
+import os
+import json
+from nanda_adapter.core.registry import LocalRegistry
+
+
+@pytest.fixture
+def temp_registry_file(tmp_path):
+    """Provide a temporary registry file path"""
+    return str(tmp_path / "test_registry.json")
+
+
+@pytest.fixture
+def registry(temp_registry_file):
+    """Provide a fresh LocalRegistry instance"""
+    return LocalRegistry(temp_registry_file)
+
+
+def test_register_agent(registry):
+    """Test registering a new agent"""
+    result = registry.register("agent_a", "http://localhost:6000")
+    assert result == True
+    assert registry.lookup("agent_a") == "http://localhost:6000"
+
+
+def test_register_updates_existing(registry):
+    """Test that re-registering updates the agent URL"""
+    registry.register("agent_a", "http://localhost:6000")
+    registry.register("agent_a", "http://localhost:6001")  # Update port
+    assert registry.lookup("agent_a") == "http://localhost:6001"
+
+
+def test_register_remote_host(registry):
+    """Test registering with remote host IP"""
+    result = registry.register("agent_b", "http://192.168.1.100:6002")
+    assert result == True
+    assert registry.lookup("agent_b") == "http://192.168.1.100:6002"
+
+
+def test_register_persists(temp_registry_file):
+    """Test that registration persists to file"""
+    registry1 = LocalRegistry(temp_registry_file)
+    registry1.register("agent_a", "http://localhost:6000")
+
+    # Create new registry instance (reload from file)
+    registry2 = LocalRegistry(temp_registry_file)
+    assert registry2.lookup("agent_a") == "http://localhost:6000"
+
+
+def test_register_creates_metadata(registry, temp_registry_file):
+    """Test that registration creates registered_at and last_seen timestamps"""
+    registry.register("agent_a", "http://localhost:6000")
+
+    # Read file directly
+    with open(temp_registry_file, 'r') as f:
+        data = json.load(f)
+
+    assert "agent_a" in data
+    assert "agent_url" in data["agent_a"]
+    assert "registered_at" in data["agent_a"]
+    assert "last_seen" in data["agent_a"]
+
+
+def test_lookup_nonexistent(registry):
+    """Test looking up an agent that doesn't exist"""
+    assert registry.lookup("nonexistent") is None
+
+
+def test_list_agents(registry):
+    """Test listing all registered agents"""
+    registry.register("agent_a", "http://localhost:6000")
+    registry.register("agent_b", "http://localhost:6002")
+
+    agents = registry.list()
+    assert len(agents) == 2
+
+    agent_ids = [a["agent_id"] for a in agents]
+    assert "agent_a" in agent_ids
+    assert "agent_b" in agent_ids
+
+
+def test_list_empty(registry):
+    """Test listing when no agents registered"""
+    agents = registry.list()
+    assert len(agents) == 0
+    assert agents == []
+
+
+def test_unregister(registry):
+    """Test unregistering an agent"""
+    registry.register("agent_a", "http://localhost:6000")
+    assert registry.lookup("agent_a") is not None
+
+    result = registry.unregister("agent_a")
+    assert result == True
+    assert registry.lookup("agent_a") is None
+
+
+def test_unregister_nonexistent(registry):
+    """Test unregistering an agent that doesn't exist"""
+    result = registry.unregister("nonexistent")
+    assert result == False
+
+
+def test_unregister_persists(temp_registry_file):
+    """Test that unregistration persists to file"""
+    registry1 = LocalRegistry(temp_registry_file)
+    registry1.register("agent_a", "http://localhost:6000")
+    registry1.unregister("agent_a")
+
+    # Reload from file
+    registry2 = LocalRegistry(temp_registry_file)
+    assert registry2.lookup("agent_a") is None
+
+
+def test_clear(registry):
+    """Test clearing all agents"""
+    registry.register("agent_a", "http://localhost:6000")
+    registry.register("agent_b", "http://localhost:6002")
+    assert len(registry.list()) == 2
+
+    registry.clear()
+    assert len(registry.list()) == 0
+
+
+def test_clear_persists(temp_registry_file):
+    """Test that clear persists to file"""
+    registry1 = LocalRegistry(temp_registry_file)
+    registry1.register("agent_a", "http://localhost:6000")
+    registry1.clear()
+
+    # Reload from file
+    registry2 = LocalRegistry(temp_registry_file)
+    assert len(registry2.list()) == 0
+
+
+def test_corrupted_file_handling(temp_registry_file):
+    """Test that registry handles corrupted JSON files gracefully"""
+    # Write invalid JSON
+    with open(temp_registry_file, 'w') as f:
+        f.write("{ invalid json }")
+
+    # Should not crash, should start fresh
+    registry = LocalRegistry(temp_registry_file)
+    assert len(registry.list()) == 0
+
+
+def test_multiple_agents(registry):
+    """Test registering and managing multiple agents"""
+    agents = [
+        ("agent_a", "http://localhost:6000"),
+        ("agent_b", "http://localhost:6002"),
+        ("agent_c", "http://192.168.1.100:6004"),
+        ("agent_d", "http://192.168.1.101:6000"),
+    ]
+
+    for agent_id, url in agents:
+        registry.register(agent_id, url)
+
+    assert len(registry.list()) == 4
+
+    for agent_id, url in agents:
+        assert registry.lookup(agent_id) == url
+
+
+def test_file_format(registry, temp_registry_file):
+    """Test that registry file is properly formatted JSON"""
+    registry.register("agent_a", "http://localhost:6000")
+
+    # Read and parse file
+    with open(temp_registry_file, 'r') as f:
+        data = json.load(f)
+
+    # Verify structure
+    assert isinstance(data, dict)
+    assert "agent_a" in data
+    assert isinstance(data["agent_a"], dict)
+    assert data["agent_a"]["agent_url"] == "http://localhost:6000"

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -1,0 +1,275 @@
+"""
+Unit tests for MessageRouter.
+
+Tests message routing, command handling, and loop prevention.
+"""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from nanda_adapter.core.router import MessageRouter
+from nanda_adapter.core.registry import LocalRegistry
+from nanda_adapter.core.protocol import A2AMessage
+
+
+@pytest.fixture
+def registry(tmp_path):
+    """Provide a registry with test agents."""
+    reg = LocalRegistry(str(tmp_path / "test_registry.json"))
+    reg.register("agent_b", "http://localhost:6002")
+    reg.register("agent_c", "http://192.168.1.100:6004")
+    return reg
+
+
+@pytest.fixture
+def router(registry):
+    """Provide a basic router without handlers."""
+    return MessageRouter("agent_a", registry)
+
+
+@pytest.fixture
+def router_with_claude(registry):
+    """Provide router with mocked Claude handler."""
+    claude_mock = Mock(return_value="Claude says: 42")
+    return MessageRouter("agent_a", registry, claude_handler=claude_mock)
+
+
+@pytest.fixture
+def router_with_improver(registry):
+    """Provide router with message improver."""
+    improver = lambda text: text.upper()
+    return MessageRouter("agent_a", registry, improver=improver)
+
+
+class TestRouterInit:
+    """Tests for router initialization."""
+
+    def test_create_router(self, registry):
+        """Test creating a router."""
+        router = MessageRouter("agent_a", registry)
+        assert router.agent_id == "agent_a"
+        assert router.registry == registry
+        assert router.improver is None
+        assert router.claude_handler is None
+
+    def test_create_router_with_handlers(self, registry):
+        """Test creating router with handlers."""
+        improver = lambda x: x.upper()
+        claude = lambda x: "response"
+
+        router = MessageRouter("agent_a", registry, improver, claude)
+        assert router.improver is not None
+        assert router.claude_handler is not None
+
+    def test_empty_agent_id_raises_error(self, registry):
+        """Test that empty agent_id raises ValueError."""
+        with pytest.raises(ValueError, match="agent_id cannot be empty"):
+            MessageRouter("", registry)
+
+    def test_none_registry_raises_error(self):
+        """Test that None registry raises ValueError."""
+        with pytest.raises(ValueError, match="registry cannot be None"):
+            MessageRouter("agent_a", None)
+
+
+class TestRouteDispatch:
+    """Tests for route() method dispatch logic."""
+
+    def test_route_agent_message(self, router):
+        """Test that @agent_id routes to agent handler."""
+        with patch.object(router, '_handle_agent_message', return_value="sent"):
+            result = router.route("@agent_b hello", "conv_001")
+            router._handle_agent_message.assert_called_once()
+
+    def test_route_command(self, router):
+        """Test that /command routes to command handler."""
+        with patch.object(router, '_handle_command', return_value="help"):
+            result = router.route("/help", "conv_001")
+            router._handle_command.assert_called_once()
+
+    def test_route_default(self, router):
+        """Test that plain text routes to default handler."""
+        with patch.object(router, '_handle_default', return_value="response"):
+            result = router.route("Hello", "conv_001")
+            router._handle_default.assert_called_once()
+
+    def test_route_strips_whitespace(self, router):
+        """Test that leading/trailing whitespace is stripped."""
+        with patch.object(router, '_handle_command', return_value="help"):
+            router.route("  /help  ", "conv_001")
+            # Would fail to match /help if not stripped
+
+
+class TestHandleCommand:
+    """Tests for command handling."""
+
+    def test_help_command(self, router):
+        """Test /help command."""
+        result = router.route("/help", "conv_001")
+        assert "Available commands" in result
+        assert "/help" in result
+        assert "/query" in result
+        assert "@<agent_id>" in result
+
+    def test_query_command_with_claude(self, router_with_claude):
+        """Test /query command with Claude handler."""
+        result = router_with_claude.route("/query What is 2+2?", "conv_001")
+        assert "Claude says: 42" in result
+        router_with_claude.claude_handler.assert_called_once_with("What is 2+2?")
+
+    def test_query_command_without_claude(self, router):
+        """Test /query command without Claude handler."""
+        result = router.route("/query test", "conv_001")
+        assert "Claude handler not configured" in result
+
+    def test_query_command_without_text(self, router_with_claude):
+        """Test /query without question text."""
+        result = router_with_claude.route("/query", "conv_001")
+        assert "Usage:" in result
+
+    def test_unknown_command(self, router):
+        """Test unknown command."""
+        result = router.route("/unknown", "conv_001")
+        assert "Unknown command" in result
+        assert "Try /help" in result
+
+
+class TestHandleDefault:
+    """Tests for default message handling."""
+
+    def test_default_with_claude(self, router_with_claude):
+        """Test default handler queries Claude."""
+        result = router_with_claude.route("What is 2+2?", "conv_001")
+        assert "Claude says: 42" in result
+
+    def test_default_without_claude(self, router):
+        """Test default handler without Claude."""
+        result = router.route("Hello", "conv_001")
+        assert "Claude handler not configured" in result
+
+
+class TestQueryClaude:
+    """Tests for Claude query functionality."""
+
+    def test_query_claude_success(self, router_with_claude):
+        """Test successful Claude query."""
+        result = router_with_claude._query_claude("test query")
+        assert "Claude says: 42" in result
+
+    def test_query_claude_no_handler(self, router):
+        """Test query without handler."""
+        result = router._query_claude("test")
+        assert "Claude handler not configured" in result
+
+    def test_query_claude_handler_raises(self, registry):
+        """Test Claude handler that raises exception."""
+        bad_handler = Mock(side_effect=Exception("API error"))
+        router = MessageRouter("agent_a", registry, claude_handler=bad_handler)
+
+        result = router._query_claude("test")
+        assert "Error querying Claude" in result
+        assert "API error" in result
+
+
+class TestMessageImprovement:
+    """Tests for message improvement."""
+
+    def test_improvement_applied(self, router_with_improver):
+        """Test that improver is applied to outgoing messages."""
+        # We can't easily test the actual sending without mocking A2AClient,
+        # but we can verify the improver function itself
+        assert router_with_improver.improver("hello") == "HELLO"
+
+    def test_improvement_failure_doesnt_crash(self, registry):
+        """Test that improvement failure doesn't prevent sending."""
+        bad_improver = Mock(side_effect=Exception("Improvement failed"))
+        router = MessageRouter("agent_a", registry, improver=bad_improver)
+
+        # Should not raise, should handle gracefully
+        # (Actual test would need to mock A2AClient)
+        assert router.improver is not None
+
+
+class TestLoopPrevention:
+    """Tests for depth-based loop prevention."""
+
+    def test_depth_zero_allowed(self, router):
+        """Test that depth=0 messages are sent."""
+        # Simply verify depth=0 is not blocked
+        # (Actual sending would require network mocking)
+        result = router.route("@agent_b hello", "conv_001", depth=0)
+
+        # Should not be blocked by depth limit
+        assert "Maximum depth reached" not in result
+
+    def test_depth_one_blocked(self, router):
+        """Test that depth=1 messages are blocked (max_depth=1)."""
+        result = router.route("@agent_b hello", "conv_001", depth=1)
+        assert "Maximum depth reached" in result
+        assert "depth=1" in result
+
+    def test_depth_higher_blocked(self, router):
+        """Test that depth>1 messages are blocked."""
+        result = router.route("@agent_b hello", "conv_001", depth=5)
+        assert "Maximum depth reached" in result
+
+
+class TestAgentLookup:
+    """Tests for agent registry lookup."""
+
+    def test_lookup_existing_agent(self, router):
+        """Test looking up agent that exists."""
+        # agent_b was registered in fixture
+        url = router.registry.lookup("agent_b")
+        assert url == "http://localhost:6002"
+
+    def test_lookup_nonexistent_agent(self, router):
+        """Test looking up agent that doesn't exist."""
+        result = router.route("@nonexistent hello", "conv_001")
+        assert "not found in registry" in result
+        assert "nonexistent" in result
+
+
+class TestMessageParsing:
+    """Tests for message parsing."""
+
+    def test_parse_agent_message_basic(self, router):
+        """Test parsing basic @agent_id message."""
+        # Should not crash, validates format
+        result = router.route("@agent_b Hello world", "conv_001")
+        # (Actual sending would be mocked in integration tests)
+
+    def test_parse_agent_message_no_text(self, router):
+        """Test @agent_id without message text."""
+        result = router.route("@agent_b", "conv_001")
+        assert "Invalid format" in result
+        assert "Use '@agent_id message'" in result
+
+    def test_parse_agent_message_multiword(self, router):
+        """Test @agent_id with multi-word message."""
+        # Should handle spaces in message correctly
+        result = router.route("@agent_b This is a longer message", "conv_001")
+        # Should not error on parsing
+
+
+class TestEdgeCases:
+    """Tests for edge cases and error handling."""
+
+    def test_empty_message(self, router):
+        """Test routing empty message."""
+        result = router.route("", "conv_001")
+        # Should handle gracefully (routes to default)
+
+    def test_whitespace_only_message(self, router):
+        """Test routing whitespace-only message."""
+        result = router.route("   ", "conv_001")
+        # Should handle gracefully
+
+    def test_special_characters_in_message(self, router_with_claude):
+        """Test message with special characters."""
+        result = router_with_claude.route("What about @#$%?", "conv_001")
+        # Should handle special chars in default/Claude query
+
+    def test_unicode_in_message(self, router_with_claude):
+        """Test message with unicode."""
+        result = router_with_claude.route("你好 🎉", "conv_001")
+        # Should handle unicode


### PR DESCRIPTION
## Summary

This PR implements a complete local development MVP for NANDA Adapter v2.0, enabling simple agent-to-agent communication without external registries, SSL certificates, or complex setup.

### Key Features

- **File-Based Registry** - No MongoDB or external services (`.nanda_registry.json`)
- **HTTP for Local Development** - No SSL certificates needed for localhost
- **Loop Prevention** - Depth tracking prevents infinite agent-to-agent loops
- **JSONL Logging** - Easy debugging with standard tools
- **Optional Claude Integration** - Works with or without Anthropic API key
- **host:port Flexibility** - Supports localhost and remote IPs (e.g., 192.168.1.100:6002)
- **Modern Python** - Type hints, comprehensive docstrings, best practices
- **101 Unit Tests** - All passing with comprehensive coverage

### New Modules (~650 LOC)

1. **`nanda_adapter/core/registry.py`** (123 LOC)
   - File-based JSON registry for local agent discovery
   - CRUD operations with automatic persistence
   - 16 unit tests

2. **`nanda_adapter/core/protocol.py`** (190 LOC)
   - A2A message format with depth tracking
   - Loop prevention mechanism (depth/max_depth fields)
   - Message validation and parsing
   - 30 unit tests

3. **`nanda_adapter/core/logger.py`** (117 LOC)
   - JSONL conversation logging
   - Per-agent, per-conversation log files
   - 23 unit tests

4. **`nanda_adapter/core/router.py`** (220 LOC)
   - Message routing with @agent_id syntax
   - Command handling (/help, /query)
   - Loop prevention enforcement
   - 32 unit tests

5. **`nanda_adapter/simple.py`** (340 LOC)
   - SimpleNANDA entry point
   - Lazy Anthropic initialization (bug fix)
   - Optional Claude support
   - host:port parsing

### Examples

- **`examples/two_agents_local.py`** - Two agents communicating locally with Claude
- **`examples/simple_agent_no_claude.py`** - Agent with custom logic, no API key required

### Documentation

- **`README_MVP.md`** - Comprehensive quick-start guide (2-minute setup)

### Quick Start

**Terminal 1:**
```bash
python examples/two_agents_local.py agent_a
```

**Terminal 2:**
```bash
python examples/two_agents_local.py agent_b
```

**Terminal 3:**
```bash
curl -X POST http://localhost:6000/a2a \
  -H "Content-Type: application/json" \
  -d '{"role":"user","content":{"type":"text","text":"@agent_b What is 2+2?"},"conversation_id":"test"}'
```

### Test Coverage

All 101 tests passing:
```bash
python -m pytest tests/unit/ -v
```

- `test_registry.py`: 16 tests
- `test_protocol.py`: 30 tests
- `test_router.py`: 32 tests
- `test_logger.py`: 23 tests

### Bug Fixes

- **Lazy Anthropic Initialization** - API key now loaded only when needed, not at import time
- **Shared Registry Path** - Fixed agent discovery by using explicit shared registry path

### Breaking Changes

None. This is a new module that can coexist with v1.x code. The `__init__.py` has been updated with backward-compatible imports.

### Comparison with v1.x

| Feature | v1.x | v2.0 MVP |
|---------|------|----------|
| **Registry** | External HTTPS | File-based JSON |
| **SSL** | Required | Not needed (HTTP) |
| **Setup Time** | ~15 min | < 2 min |
| **Env Vars** | 16 | 1 (API key) |
| **Offline** | No | Yes |
| **Tests** | 0 | 101 |
| **LOC** | ~2,400 | ~650 core |